### PR TITLE
Removed deprecated options

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -6,9 +6,6 @@ assets:
   settings.xml: yegor256/home#assets/asto/settings.xml
   pubring.gpg: yegor256/home#assets/pubring.gpg
   secring.gpg: yegor256/home#assets/secring.gpg
-env:
-  MAVEN_OPTS: -XX:MaxPermSize=256m -Xmx1g
-  JAVA_OPTS: -XX:MaxPermSize=256m -Xmx1g
 install: |
   sudo locale-gen en_US en_US.UTF-8
   sudo dpkg-reconfigure locales


### PR DESCRIPTION
#1 - removed deprecated JDK option `MaxPermSize`

> Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0

`mx1g` also not needed here, since Java heap size will set to the maximum available memory on the running machine. This options usually used to reduce the size of available memory.