### PR TITLE
#51 - Added Storage.move() method

### DIFF
--- a/src/main/java/com/artipie/asto/Storage.java
+++ b/src/main/java/com/artipie/asto/Storage.java
@@ -71,6 +71,15 @@ public interface Storage {
     CompletableFuture<Void> save(Key key, Flow.Publisher<ByteBuffer> content);
 
     /**
+     * Moves value from one location to another.
+     *
+     * @param source Source key.
+     * @param destination Destination key.
+     * @return Completion or error signal.
+     */
+    CompletableFuture<Void> move(Key source, Key destination);
+
+    /**
      * Obtain bytes by key.
      *
      * @param key The key

--- a/src/main/java/com/artipie/asto/blocking/BlockingStorage.java
+++ b/src/main/java/com/artipie/asto/blocking/BlockingStorage.java
@@ -92,6 +92,16 @@ public class BlockingStorage {
     }
 
     /**
+     * Moves value from one location to another.
+     *
+     * @param source Source key.
+     * @param destination Destination key.
+     */
+    public void move(final Key source, final Key destination) {
+        this.storage.move(source, destination).blockingAwait();
+    }
+
+    /**
      * Obtain value for the specified key.
      *
      * @param key The key

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -130,7 +130,7 @@ public final class FileStorage implements Storage {
                 dest -> new RxFile(this.path(source)).move(dest)
             )
             .to(CompletableInterop.await())
-            .<Void>thenApply(o -> null)
+            .<Void>thenApply(file -> null)
             .toCompletableFuture();
     }
 

--- a/src/main/java/com/artipie/asto/fs/FileSystemTransaction.java
+++ b/src/main/java/com/artipie/asto/fs/FileSystemTransaction.java
@@ -65,6 +65,11 @@ public final class FileSystemTransaction implements Transaction {
     }
 
     @Override
+    public CompletableFuture<Void> move(final Key source, final Key destination) {
+        return this.parent.move(source, destination);
+    }
+
+    @Override
     public CompletableFuture<Void> save(final Key key, final Flow.Publisher<ByteBuffer> content) {
         return this.parent.save(key, content);
     }

--- a/src/main/java/com/artipie/asto/fs/RxFile.java
+++ b/src/main/java/com/artipie/asto/fs/RxFile.java
@@ -26,6 +26,7 @@ package com.artipie.asto.fs;
 import com.artipie.asto.Remaining;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
+import io.vertx.core.file.CopyOptions;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.core.buffer.Buffer;
@@ -99,5 +100,18 @@ public class RxFile {
                         .subscribe(asyncFile.toSubscriber().onComplete(emitter::onComplete))
                 )
             ).delay(delay, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Move file to new location.
+     * @param target Target path the file is moved to.
+     * @return Completion or error signal
+     */
+    public Completable move(final Path target) {
+        return this.fls.rxMove(
+            this.file.toString(),
+            target.toString(),
+            new CopyOptions().setReplaceExisting(true)
+        );
     }
 }

--- a/src/main/java/com/artipie/asto/rx/RxStorage.java
+++ b/src/main/java/com/artipie/asto/rx/RxStorage.java
@@ -67,6 +67,15 @@ public interface RxStorage {
     Completable save(Key key, Flowable<ByteBuffer> content);
 
     /**
+     * Moves value from one location to another.
+     *
+     * @param source Source key.
+     * @param destination Destination key.
+     * @return Completion or error signal.
+     */
+    Completable move(Key source, Key destination);
+
+    /**
      * Obtain bytes by key.
      *
      * @param key The key

--- a/src/main/java/com/artipie/asto/rx/RxStorageWrapper.java
+++ b/src/main/java/com/artipie/asto/rx/RxStorageWrapper.java
@@ -94,6 +94,13 @@ public final class RxStorageWrapper implements RxStorage {
         );
     }
 
+    @Override
+    public Completable move(final Key source, final Key destination) {
+        return CompletableInterop.fromFuture(
+            this.storage.move(source, destination)
+        );
+    }
+
     /**
      * Obtain bytes by key.
      *

--- a/src/main/java/com/artipie/asto/rx/RxTransactionWrapper.java
+++ b/src/main/java/com/artipie/asto/rx/RxTransactionWrapper.java
@@ -86,6 +86,13 @@ public final class RxTransactionWrapper implements RxTransaction {
     }
 
     @Override
+    public Completable move(final Key source, final Key destination) {
+        return CompletableInterop.fromFuture(
+            this.wrapped.move(source, destination)
+        );
+    }
+
+    @Override
     public Single<Flowable<ByteBuffer>> value(final Key key) {
         return SingleInterop.fromFuture(this.wrapped.value(key))
             .map(flow -> Flowable.fromPublisher(FlowAdapters.toPublisher(flow)));

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -109,4 +109,17 @@ public final class FileStorageTest {
             Matchers.equalTo(content)
         );
     }
+
+    @Test
+    public void move() throws Exception {
+        final byte[] data = "data".getBytes();
+        final BlockingStorage storage = new BlockingStorage(
+            new FileStorage(this.folder.newFolder().toPath())
+        );
+        final Key source = new Key.From("from");
+        storage.save(source, data);
+        final Key destination = new Key.From("to");
+        storage.move(source, destination);
+        MatcherAssert.assertThat(storage.value(destination), Matchers.equalTo(data));
+    }
 }

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -100,11 +100,9 @@ final class FileStorageTest {
     }
 
     @Test
-    public void move() throws Exception {
+    void move(@TempDir final Path tmp) {
         final byte[] data = "data".getBytes();
-        final BlockingStorage storage = new BlockingStorage(
-            new FileStorage(this.folder.newFolder().toPath())
-        );
+        final BlockingStorage storage = new BlockingStorage(new FileStorage(tmp));
         final Key source = new Key.From("from");
         storage.save(source, data);
         final Key destination = new Key.From("to");


### PR DESCRIPTION
This pull requests adds move feature to ASTO storage, e.g. atomic operation of moving content from one key to another that could be handled efficiently by storage implementation.
The feature is requested by adapter modules using ASTO storage, see https://github.com/artipie/nuget-adapter/issues/21