### PR TITLE
#62 - Storage.list() method accepts Key as prefix

### DIFF
--- a/src/main/java/com/artipie/asto/Storage.java
+++ b/src/main/java/com/artipie/asto/Storage.java
@@ -51,15 +51,13 @@ public interface Storage {
     CompletableFuture<Boolean> exists(Key key);
 
     /**
-     * Return the list of object names that start with this prefix, for
+     * Return the list of keys that start with this prefix, for
      * example "foo/bar/".
      *
-     * The prefix must end with a slash.
-     *
-     * @param prefix The prefix, ended with a slash
-     * @return List of object keys/names
+     * @param prefix The prefix.
+     * @return Collection of relative keys.
      */
-    CompletableFuture<Collection<Key>> list(String prefix);
+    CompletableFuture<Collection<Key>> list(Key prefix);
 
     /**
      * Saves the bytes to the specified key.

--- a/src/main/java/com/artipie/asto/blocking/BlockingStorage.java
+++ b/src/main/java/com/artipie/asto/blocking/BlockingStorage.java
@@ -66,15 +66,13 @@ public class BlockingStorage {
     }
 
     /**
-     * Return the list of object names that start with this prefix, for
+     * Return the list of keys that start with this prefix, for
      * example "foo/bar/".
-     * <p>
-     * The prefix must end with a slash.
      *
-     * @param prefix The prefix, ended with a slash
-     * @return List of object keys/names
+     * @param prefix The prefix.
+     * @return Collection of relative keys.
      */
-    public Collection<Key> list(final String prefix) {
+    public Collection<Key> list(final Key prefix) {
         return this.storage.list(prefix).blockingGet();
     }
 

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -32,6 +32,7 @@ import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import java.nio.ByteBuffer;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -84,6 +85,7 @@ public final class FileStorage implements Storage {
                         .filter(Files::isRegularFile)
                         .map(Path::toString)
                         .map(p -> p.substring(dirnamelen))
+                        .map(s -> s.split(FileSystems.getDefault().getSeparator()))
                         .map(Key.From::new)
                         .sorted(Comparator.comparing(Key.From::string))
                         .collect(Collectors.toList());

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
@@ -84,6 +85,7 @@ public final class FileStorage implements Storage {
                         .map(Path::toString)
                         .map(p -> p.substring(dirnamelen))
                         .map(Key.From::new)
+                        .sorted(Comparator.comparing(Key.From::string))
                         .collect(Collectors.toList());
                 } else {
                     keys = Collections.emptyList();

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
@@ -75,13 +76,18 @@ public final class FileStorage implements Storage {
         return Single.fromCallable(
             () -> {
                 final Path path = this.path(prefix);
-                final int dirnamelen = path.toString().length() - prefix.string().length();
-                final Collection<Key> keys = Files.walk(path)
-                    .filter(Files::isRegularFile)
-                    .map(Path::toString)
-                    .map(p -> p.substring(dirnamelen))
-                    .map(Key.From::new)
-                    .collect(Collectors.toList());
+                final Collection<Key> keys;
+                if (Files.exists(path)) {
+                    final int dirnamelen = path.toString().length() - prefix.string().length();
+                    keys = Files.walk(path)
+                        .filter(Files::isRegularFile)
+                        .map(Path::toString)
+                        .map(p -> p.substring(dirnamelen))
+                        .map(Key.From::new)
+                        .collect(Collectors.toList());
+                } else {
+                    keys = Collections.emptyList();
+                }
                 Logger.info(
                     this,
                     "Found %d objects by the prefix \"%s\" in %s by %s: %s",

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -32,7 +32,6 @@ import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import java.nio.ByteBuffer;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -72,21 +71,11 @@ public final class FileStorage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Collection<Key>> list(final String prefix) {
+    public CompletableFuture<Collection<Key>> list(final Key prefix) {
         return Single.fromCallable(
             () -> {
-                final String separator = FileSystems.getDefault().getSeparator();
-                if (!prefix.endsWith(separator)) {
-                    throw new IllegalArgumentException(
-                        String.format(
-                            "The prefix must end with '%s': \"%s\"",
-                            prefix,
-                            separator
-                        )
-                    );
-                }
-                final Path path = Paths.get(this.dir.toString(), prefix);
-                final int dirnamelen = path.toString().length() - prefix.length() + 1;
+                final Path path = this.path(prefix);
+                final int dirnamelen = path.toString().length() - prefix.string().length();
                 final Collection<Key> keys = Files.walk(path)
                     .filter(Files::isRegularFile)
                     .map(Path::toString)

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -103,7 +103,11 @@ public final class FileStorage implements Storage {
                         .filter(Files::isRegularFile)
                         .map(Path::toString)
                         .map(p -> p.substring(dirnamelen))
-                        .map(s -> s.split(FileSystems.getDefault().getSeparator()))
+                        .map(
+                            s -> s.split(
+                                FileSystems.getDefault().getSeparator().replace("\\", "\\\\")
+                            )
+                        )
                         .map(Key.From::new)
                         .sorted(Comparator.comparing(Key.From::string))
                         .collect(Collectors.toList());

--- a/src/main/java/com/artipie/asto/fs/FileSystemTransaction.java
+++ b/src/main/java/com/artipie/asto/fs/FileSystemTransaction.java
@@ -60,7 +60,7 @@ public final class FileSystemTransaction implements Transaction {
     }
 
     @Override
-    public CompletableFuture<Collection<Key>> list(final String prefix) {
+    public CompletableFuture<Collection<Key>> list(final Key prefix) {
         return this.parent.list(prefix);
     }
 

--- a/src/main/java/com/artipie/asto/rx/RxStorage.java
+++ b/src/main/java/com/artipie/asto/rx/RxStorage.java
@@ -47,15 +47,13 @@ public interface RxStorage {
     Single<Boolean> exists(Key key);
 
     /**
-     * Return the list of object names that start with this prefix, for
+     * Return the list of keys that start with this prefix, for
      * example "foo/bar/".
      *
-     * The prefix must end with a slash.
-     *
-     * @param prefix The prefix, ended with a slash
-     * @return List of object keys/names
+     * @param prefix The prefix.
+     * @return Collection of relative keys.
      */
-    Single<Collection<Key>> list(String prefix);
+    Single<Collection<Key>> list(Key prefix);
 
     /**
      * Saves the bytes to the specified key.

--- a/src/main/java/com/artipie/asto/rx/RxStorageWrapper.java
+++ b/src/main/java/com/artipie/asto/rx/RxStorageWrapper.java
@@ -65,16 +65,8 @@ public final class RxStorageWrapper implements RxStorage {
         return SingleInterop.fromFuture(this.storage.exists(key));
     }
 
-    /**
-     * Return the list of object names that start with this prefix, for
-     * example {@code foo/bar/}.
-     *<p>
-     * The prefix must end with a slash.
-     *
-     * @param prefix The prefix, ended with a slash
-     * @return List of object keys/names
-     */
-    public Single<Collection<Key>> list(final String prefix) {
+    @Override
+    public Single<Collection<Key>> list(final Key prefix) {
         return SingleInterop.fromFuture(this.storage.list(prefix));
     }
 

--- a/src/main/java/com/artipie/asto/rx/RxTransactionWrapper.java
+++ b/src/main/java/com/artipie/asto/rx/RxTransactionWrapper.java
@@ -71,7 +71,7 @@ public final class RxTransactionWrapper implements RxTransaction {
     }
 
     @Override
-    public Single<Collection<Key>> list(final String prefix) {
+    public Single<Collection<Key>> list(final Key prefix) {
         return SingleInterop.fromFuture(this.wrapped.list(prefix));
     }
 

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -129,4 +129,14 @@ final class FileStorageTest {
             Matchers.equalTo(Arrays.asList("a\\b\\2", "a\\b\\c\\1"))
         );
     }
+
+    @Test
+    void listEmpty(@TempDir final Path tmp) {
+        final BlockingStorage storage = new BlockingStorage(new FileStorage(tmp));
+        final Collection<String> keys = storage.list(new Key.From("a", "b"))
+            .stream()
+            .map(Key::string)
+            .collect(Collectors.toList());
+        MatcherAssert.assertThat(keys, Matchers.empty());
+    }
 }

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -126,7 +126,7 @@ final class FileStorageTest {
             .collect(Collectors.toList());
         MatcherAssert.assertThat(
             keys,
-            Matchers.equalTo(Arrays.asList("a\\b\\2", "a\\b\\c\\1"))
+            Matchers.equalTo(Arrays.asList("a/b/2", "a/b/c/1"))
         );
     }
 

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -30,6 +30,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -108,5 +110,23 @@ final class FileStorageTest {
         final Key destination = new Key.From("to");
         storage.move(source, destination);
         MatcherAssert.assertThat(storage.value(destination), Matchers.equalTo(data));
+    }
+
+    @Test
+    void list(@TempDir final Path tmp) {
+        final byte[] data = "some data".getBytes();
+        final BlockingStorage storage = new BlockingStorage(new FileStorage(tmp));
+        storage.save(new Key.From("a", "b", "c", "1"), data);
+        storage.save(new Key.From("a", "b", "2"), data);
+        storage.save(new Key.From("a", "z"), data);
+        storage.save(new Key.From("z"), data);
+        final Collection<String> keys = storage.list(new Key.From("a", "b"))
+            .stream()
+            .map(Key::string)
+            .collect(Collectors.toList());
+        MatcherAssert.assertThat(
+            keys,
+            Matchers.equalTo(Arrays.asList("a\\b\\2", "a\\b\\c\\1"))
+        );
     }
 }


### PR DESCRIPTION
Issue: #62 
This PR modifies Storage interface, FileStorage implementation and related classes such as BlockingStorage, RxStorage etc