### PR TITLE
Using jdk8 to build release binary

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,5 +1,5 @@
 docker:
-  image: g4s8/rultor-jdk11:alpine3.10
+  image: g4s8/rultor:alpine3.10
 assets:
   settings.xml: yegor256/home#assets/artipie/settings.xml
   pubring.gpg: yegor256/home#assets/pubring.gpg


### PR DESCRIPTION
#82 - using jdk8 docker image to release jars