### PR TITLE
Reproduced and fixed rxfile

### DIFF
--- a/src/main/java/com/artipie/asto/fs/RxFile.java
+++ b/src/main/java/com/artipie/asto/fs/RxFile.java
@@ -129,7 +129,11 @@ public class RxFile {
                     )
                     .map(buf -> new Remaining(buf).bytes())
                     .orElse(new byte[0]);
-                Files.write(this.file, bytes, StandardOpenOption.CREATE);
+                Files.write(
+                    this.file,
+                    bytes,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING
+                );
             }
         );
     }


### PR DESCRIPTION
#91 - discovered the bug in `RxFile` when overwriting existing file with longer string: the file won't be truncated in this case.