### PR TITLE
#94 - Key.From does not allow empty parts

### DIFF
--- a/src/main/java/com/artipie/asto/Key.java
+++ b/src/main/java/com/artipie/asto/Key.java
@@ -128,6 +128,9 @@ public interface Key {
         @Override
         public String string() {
             for (final String part : this.parts) {
+                if (part.isEmpty()) {
+                    throw new IllegalStateException("Empty parts are not allowed");
+                }
                 if (part.contains(From.DELIMITER)) {
                     throw new IllegalStateException(String.format("Invalid part: '%s'", part));
                 }

--- a/src/test/java/com/artipie/asto/KeyTest.java
+++ b/src/test/java/com/artipie/asto/KeyTest.java
@@ -26,6 +26,7 @@ package com.artipie.asto;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -66,5 +67,10 @@ final class KeyTest {
             new Key.From(string).string(),
             Matchers.equalTo(string)
         );
+    }
+
+    @Test
+    void keyWithEmptyPart() {
+        Assertions.assertThrows(Exception.class, () -> new Key.From("", "something").string());
     }
 }


### PR DESCRIPTION
Closes issue #94 
Added check for part being empty to Key.From.string() method.