### PR TITLE
Remove RxFile(Path) constructor

### DIFF
--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -32,7 +32,6 @@ import hu.akarnokd.rxjava2.interop.CompletableInterop;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
-import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.core.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -58,18 +57,9 @@ public final class FileStorage implements Storage {
     private final Path dir;
 
     /**
-     * The Vert.x.
+     * The Vert.x file system.
      */
     private final FileSystem fls;
-
-    /**
-     * Ctor.
-     *
-     * @param path The path to the dir.
-     */
-    public FileStorage(final Path path) {
-        this(path, Vertx.vertx().fileSystem());
-    }
 
     /**
      * Ctor.

--- a/src/main/java/com/artipie/asto/fs/RxFile.java
+++ b/src/main/java/com/artipie/asto/fs/RxFile.java
@@ -60,14 +60,6 @@ public class RxFile {
     /**
      * Ctor.
      * @param file The wrapped file.
-     */
-    public RxFile(final Path file) {
-        this(file, Vertx.vertx().fileSystem());
-    }
-
-    /**
-     * Ctor.
-     * @param file The wrapped file.
      * @param fls The file system.
      */
     public RxFile(final Path file, final FileSystem fls) {

--- a/src/main/java/com/artipie/asto/fs/RxFile.java
+++ b/src/main/java/com/artipie/asto/fs/RxFile.java
@@ -30,7 +30,6 @@ import io.reactivex.Single;
 import io.vertx.core.file.CopyOptions;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.reactivex.core.Promise;
-import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.core.file.FileSystem;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;

--- a/src/test/java/com/artipie/asto/RxFileTest.java
+++ b/src/test/java/com/artipie/asto/RxFileTest.java
@@ -46,10 +46,11 @@ final class RxFileTest {
 
     @Test
     public void rxFileFlowWorks(@TempDir final Path tmp) throws IOException {
+        final Vertx vertx = Vertx.vertx();
         final String hello = "hello-world";
         final Path temp = tmp.resolve("txt-file");
         Files.write(temp, hello.getBytes());
-        final String content = new RxFile(temp)
+        final String content = new RxFile(temp, vertx.fileSystem())
             .flow()
             .rebatchRequests(1)
             .toList()
@@ -61,19 +62,22 @@ final class RxFileTest {
             .map(bytes -> new String(new ByteArray(bytes).primitiveBytes()))
             .blockingGet();
         MatcherAssert.assertThat(hello, Matchers.equalTo(content));
+        vertx.close();
     }
 
     @Test
     public void rxFileTruncatesExistingFile(@TempDir final Path tmp) throws Exception {
+        final Vertx vertx = Vertx.vertx();
         final String one = "one";
         final String two = "two111";
         final Path target = tmp.resolve("target.txt");
-        new RxFile(target).save(pubFromString(two)).blockingAwait();
-        new RxFile(target).save(pubFromString(one)).blockingAwait();
+        new RxFile(target, vertx.fileSystem()).save(pubFromString(two)).blockingAwait();
+        new RxFile(target, vertx.fileSystem()).save(pubFromString(one)).blockingAwait();
         MatcherAssert.assertThat(
             new String(Files.readAllBytes(target), StandardCharsets.UTF_8),
             Matchers.equalTo(one)
         );
+        vertx.close();
     }
 
     // @checkstyle MagicNumberCheck (1 line)


### PR DESCRIPTION
In general, it is a bad idea to use this constructor in production code, because it creates 2xCPU amount of threads. 