### PR TITLE
#87 - S3StorageTest refactoring

### DIFF
--- a/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
+++ b/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
@@ -97,6 +97,17 @@ public final class StorageSaveAndLoadTest {
     }
 
     @TestTemplate
+    void shouldFailToSaveErrorContent(final Storage storage) {
+        Assertions.assertThrows(
+            Exception.class,
+            () -> storage.save(
+                new Key.From("shouldFailToSaveErrorContent"),
+                new Content.From(Flowable.error(new IllegalStateException()))
+            ).join()
+        );
+    }
+
+    @TestTemplate
     void shouldFailToLoadAbsentValue(final Storage storage) {
         final BlockingStorage blocking = new BlockingStorage(storage);
         final Key key = new Key.From("shouldFailToLoadAbsentValue");


### PR DESCRIPTION
Part of issue #87
Removed duplication of bucket creating code in S3Storage
S3StorageTest.shouldFailToSaveMultipartUploadWhenFailedToReadContent() generalized and moved to StorageSaveAndLoadTest.shouldFailToSaveErrorContent()
shouldNotExistForUnknownObject() removed as duplicate of StorageExistsTest.shouldNotExistForUnknownKey()