### PR TITLE
#110 - Added Storage.delete() method

### DIFF
--- a/src/main/java/com/artipie/asto/Storage.java
+++ b/src/main/java/com/artipie/asto/Storage.java
@@ -84,6 +84,14 @@ public interface Storage {
     CompletableFuture<Content> value(Key key);
 
     /**
+     * Removes value from storage. Fails if value does not exist.
+     *
+     * @param key Key for value to be deleted.
+     * @return Completion or error signal.
+     */
+    CompletableFuture<Void> delete(Key key);
+
+    /**
      * Start a transaction with specified keys. These specified keys are the scope of
      * a transaction. You will be able to perform storage operations like
      * {@link Storage#save(Key, Content)} or {@link Storage#value(Key)} only in

--- a/src/main/java/com/artipie/asto/blocking/BlockingStorage.java
+++ b/src/main/java/com/artipie/asto/blocking/BlockingStorage.java
@@ -115,4 +115,13 @@ public class BlockingStorage {
                 .toArray(Byte[]::new)
         ).primitiveBytes();
     }
+
+    /**
+     * Removes value from storage. Fails if value does not exist.
+     *
+     * @param key Key for value to be deleted.
+     */
+    public void delete(final Key key) {
+        this.storage.delete(key).blockingAwait();
+    }
 }

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -146,6 +146,15 @@ public final class FileStorage implements Storage {
     }
 
     @Override
+    public CompletableFuture<Void> delete(final Key key) {
+        return CompletableFuture.supplyAsync(
+            () -> new RxFile(this.path(key), this.fls)
+        ).thenCompose(
+            file -> file.delete().to(CompletableInterop.await())
+        );
+    }
+
+    @Override
     public CompletableFuture<Content> value(final Key key) {
         return CompletableFuture.supplyAsync(
             () -> {

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -147,11 +147,11 @@ public final class FileStorage implements Storage {
 
     @Override
     public CompletableFuture<Void> delete(final Key key) {
-        return CompletableFuture.supplyAsync(
-            () -> new RxFile(this.path(key), this.fls)
-        ).thenCompose(
-            file -> file.delete().to(CompletableInterop.await())
-        );
+        return new RxFile(this.path(key), this.fls)
+            .delete()
+            .to(CompletableInterop.await())
+            .toCompletableFuture()
+            .thenCompose(ignored -> CompletableFuture.allOf());
     }
 
     @Override

--- a/src/main/java/com/artipie/asto/fs/FileSystemTransaction.java
+++ b/src/main/java/com/artipie/asto/fs/FileSystemTransaction.java
@@ -79,6 +79,11 @@ public final class FileSystemTransaction implements Transaction {
     }
 
     @Override
+    public CompletableFuture<Void> delete(final Key key) {
+        return this.parent.delete(key);
+    }
+
+    @Override
     public CompletableFuture<Transaction> transaction(
         // @checkstyle HiddenFieldCheck (1 line)
         final List<Key> keys) {

--- a/src/main/java/com/artipie/asto/fs/RxFile.java
+++ b/src/main/java/com/artipie/asto/fs/RxFile.java
@@ -145,6 +145,15 @@ public class RxFile {
     }
 
     /**
+     * Delete file.
+     *
+     * @return Completion or error signal
+     */
+    public Completable delete() {
+        return this.fls.rxDelete(this.file.toString());
+    }
+
+    /**
      * Get file size.
      *
      * @return File size in bytes.

--- a/src/main/java/com/artipie/asto/memory/InMemoryStorage.java
+++ b/src/main/java/com/artipie/asto/memory/InMemoryStorage.java
@@ -151,6 +151,23 @@ public final class InMemoryStorage implements Storage {
     }
 
     @Override
+    public CompletableFuture<Void> delete(final Key key) {
+        return CompletableFuture.runAsync(
+            () -> {
+                synchronized (this.data) {
+                    final String str = key.string();
+                    if (!this.data.containsKey(str)) {
+                        throw new IllegalArgumentException(
+                            String.format("Key does not exist: %s", str)
+                        );
+                    }
+                    this.data.remove(str);
+                }
+            }
+        );
+    }
+
+    @Override
     public CompletableFuture<Transaction> transaction(final List<Key> keys) {
         return CompletableFuture.completedFuture(new InMemoryTransaction(this));
     }

--- a/src/main/java/com/artipie/asto/memory/InMemoryTransaction.java
+++ b/src/main/java/com/artipie/asto/memory/InMemoryTransaction.java
@@ -78,6 +78,11 @@ public final class InMemoryTransaction implements Transaction {
     }
 
     @Override
+    public CompletableFuture<Void> delete(final Key key) {
+        return this.parent.delete(key);
+    }
+
+    @Override
     public CompletableFuture<Transaction> transaction(final List<Key> keys) {
         return CompletableFuture.completedFuture(this);
     }

--- a/src/main/java/com/artipie/asto/rx/RxStorage.java
+++ b/src/main/java/com/artipie/asto/rx/RxStorage.java
@@ -81,6 +81,14 @@ public interface RxStorage {
     Single<Content> value(Key key);
 
     /**
+     * Removes value from storage. Fails if value does not exist.
+     *
+     * @param key Key for value to be deleted.
+     * @return Completion or error signal.
+     */
+    Completable delete(Key key);
+
+    /**
      * Start a transaction with specified keys.
      *
      * @param keys The keys regarding which transaction is atomic

--- a/src/main/java/com/artipie/asto/rx/RxStorageWrapper.java
+++ b/src/main/java/com/artipie/asto/rx/RxStorageWrapper.java
@@ -47,6 +47,7 @@ public final class RxStorageWrapper implements RxStorage {
 
     /**
      * Ctor.
+     *
      * @param storage The storage
      */
     public RxStorageWrapper(final Storage storage) {
@@ -92,6 +93,11 @@ public final class RxStorageWrapper implements RxStorage {
      */
     public Single<Content> value(final Key key) {
         return SingleInterop.fromFuture(this.storage.value(key));
+    }
+
+    @Override
+    public Completable delete(final Key key) {
+        return CompletableInterop.fromFuture(this.storage.delete(key));
     }
 
     /**

--- a/src/main/java/com/artipie/asto/rx/RxTransactionWrapper.java
+++ b/src/main/java/com/artipie/asto/rx/RxTransactionWrapper.java
@@ -96,6 +96,11 @@ public final class RxTransactionWrapper implements RxTransaction {
     }
 
     @Override
+    public Completable delete(final Key key) {
+        return CompletableInterop.fromFuture(this.wrapped.delete(key));
+    }
+
+    @Override
     public Single<RxTransaction> transaction(final List<Key> keys) {
         return SingleInterop.fromFuture(this.wrapped.transaction(keys))
             .map(RxTransactionWrapper::new);

--- a/src/main/java/com/artipie/asto/s3/S3Storage.java
+++ b/src/main/java/com/artipie/asto/s3/S3Storage.java
@@ -182,6 +182,31 @@ public final class S3Storage implements Storage {
     }
 
     @Override
+    public CompletableFuture<Void> delete(final Key key) {
+        return this.exists(key).thenCompose(
+            exists -> {
+                final CompletableFuture<Void> deleted;
+                if (exists) {
+                    deleted = this.client.deleteObject(
+                        DeleteObjectRequest.builder()
+                            .bucket(this.bucket)
+                            .key(key.string())
+                            .build()
+                    ).thenCompose(
+                        response -> CompletableFuture.allOf()
+                    );
+                } else {
+                    deleted = new CompletableFuture<>();
+                    deleted.completeExceptionally(
+                        new IllegalArgumentException(String.format("Key does not exist: %s", key))
+                    );
+                }
+                return deleted;
+            }
+        );
+    }
+
+    @Override
     public CompletableFuture<Transaction> transaction(final List<Key> keys) {
         throw new UnsupportedOperationException();
     }

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -35,6 +35,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.io.TempDir;
  *
  * @since 0.1
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class FileStorageTest {
 
     /**
@@ -199,5 +201,33 @@ final class FileStorageTest {
             blocking.exists(parent),
             Matchers.equalTo(false)
         );
+    }
+
+    @Test
+    void shouldDeleteValue() throws Exception {
+        final Key key = new Key.From("shouldDeleteValue");
+        final byte[] data = "shouldDeleteValue-data".getBytes();
+        final BlockingStorage blocking = new BlockingStorage(this.storage);
+        blocking.save(key, data);
+        blocking.delete(key);
+        MatcherAssert.assertThat(
+            this.storage.exists(key).get(),
+            new IsEqual<>(false)
+        );
+    }
+
+    @Test
+    void shouldFailToDeleteNotExistingValue() {
+        final Key key = new Key.From("shouldFailToDeleteNotExistingValue");
+        Assertions.assertThrows(Exception.class, () -> this.storage.delete(key).get());
+    }
+
+    @Test
+    void shouldFailToDeleteParentOfSavedKey() {
+        final Key parent = new Key.From("shouldFailToDeleteParentOfSavedKey");
+        final Key key = new Key.From(parent, "child");
+        final byte[] content = "shouldFailToDeleteParentOfSavedKey-content".getBytes();
+        new BlockingStorage(this.storage).save(key, content);
+        Assertions.assertThrows(Exception.class, () -> this.storage.delete(parent).get());
     }
 }

--- a/src/test/java/com/artipie/asto/S3StorageTest.java
+++ b/src/test/java/com/artipie/asto/S3StorageTest.java
@@ -56,8 +56,9 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
  * Tests for {@link S3Storage}.
  *
  * @since 0.15
- * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (3 lines)
  */
+@SuppressWarnings("PMD.TooManyMethods")
 class S3StorageTest {
 
     /**
@@ -215,6 +216,20 @@ class S3StorageTest {
         );
         MatcherAssert.assertThat(
             client.doesObjectExist(bucket, source),
+            new IsEqual<>(false)
+        );
+    }
+
+    @Test
+    void shouldDeleteObject(final AmazonS3 client) {
+        final String bucket = UUID.randomUUID().toString();
+        client.createBucket(bucket);
+        final byte[] data = "to be deleted".getBytes();
+        final String key = "to/be/deleted";
+        client.putObject(bucket, key, new ByteArrayInputStream(data), new ObjectMetadata());
+        new BlockingStorage(this.storage(bucket)).delete(new Key.From(key));
+        MatcherAssert.assertThat(
+            client.doesObjectExist(bucket, key),
             new IsEqual<>(false)
         );
     }

--- a/src/test/java/com/artipie/asto/StorageDeleteTest.java
+++ b/src/test/java/com/artipie/asto/StorageDeleteTest.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.asto;
+
+import com.artipie.asto.blocking.BlockingStorage;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests for {@link Storage#delete(Key)}.
+ *
+ * @since 0.14
+ */
+@ExtendWith(StorageExtension.class)
+public final class StorageDeleteTest {
+
+    @TestTemplate
+    void shouldDeleteValue(final Storage storage) throws Exception {
+        final Key key = new Key.From("shouldDeleteValue");
+        final byte[] data = "data".getBytes();
+        final BlockingStorage blocking = new BlockingStorage(storage);
+        blocking.save(key, data);
+        blocking.delete(key);
+        MatcherAssert.assertThat(
+            storage.exists(key).get(),
+            new IsEqual<>(false)
+        );
+    }
+
+    @TestTemplate
+    void shouldFailToDeleteNotExistingValue(final Storage storage) {
+        final Key key = new Key.From("shouldFailToDeleteNotExistingValue");
+        Assertions.assertThrows(Exception.class, () -> storage.delete(key).get());
+    }
+
+    @TestTemplate
+    void shouldFailToDeleteParentOfSavedKey(final Storage storage) {
+        final Key parent = new Key.From("shouldFailToDeleteParentOfSavedKey");
+        final Key key = new Key.From(parent, "child");
+        final byte[] content = "content".getBytes();
+        new BlockingStorage(storage).save(key, content);
+        Assertions.assertThrows(Exception.class, () -> storage.delete(parent).get());
+    }
+}


### PR DESCRIPTION
Closes issue #110 
Added `delete()` method to `Storage` with implementations for file, S3 and in memory storage.
Also added `delete()` method to `BlockingStorage` and `RxStorage`