### PR TITLE
#153 - Removed Single.blockingGet() calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,8 +133,20 @@ SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.6.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.6.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit-platform.version}</version>
+      <version>5.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/artipie/asto/memory/InMemoryStorage.java
+++ b/src/main/java/com/artipie/asto/memory/InMemoryStorage.java
@@ -29,6 +29,7 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Remaining;
 import com.artipie.asto.Storage;
 import com.artipie.asto.Transaction;
+import hu.akarnokd.rxjava2.interop.SingleInterop;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -89,19 +90,17 @@ public final class InMemoryStorage implements Storage {
 
     @Override
     public CompletableFuture<Void> save(final Key key, final Content content) {
-        return CompletableFuture.runAsync(
-            () -> {
-                synchronized (this.data) {
-                    this.data.put(
-                        key.string(),
-                        new Remaining(
-                            new Concatenation(content).single().blockingGet(),
-                            true
-                        ).bytes()
-                    );
+        return new Concatenation(content).single().to(SingleInterop.get())
+            .thenApply(Remaining::new)
+            .thenApply(Remaining::bytes)
+            .thenAccept(
+                bytes -> {
+                    synchronized (this.data) {
+                        this.data.put(key.string(), bytes);
+                    }
                 }
-            }
-        );
+            )
+            .toCompletableFuture();
     }
 
     @Override

--- a/src/test/java/com/artipie/asto/memory/InMemoryStorageTest.java
+++ b/src/test/java/com/artipie/asto/memory/InMemoryStorageTest.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.asto.memory;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import java.util.concurrent.TimeUnit;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Tests for {@link InMemoryStorage}.
+ *
+ * @since 0.18
+ */
+class InMemoryStorageTest {
+
+    /**
+     * Storage being tested.
+     */
+    private InMemoryStorage storage;
+
+    @BeforeEach
+    void setUp() {
+        this.storage = new InMemoryStorage();
+    }
+
+    @Test
+    @Timeout(1)
+    void shouldNotBeBlockedByEndlessContent() throws Exception {
+        final Key.From key = new Key.From("data");
+        this.storage.save(
+            key,
+            new Content.From(
+                ignored -> {
+                }
+            )
+        );
+        // @checkstyle MagicNumberCheck (1 line)
+        Thread.sleep(100);
+        MatcherAssert.assertThat(
+            this.storage.exists(key).get(1, TimeUnit.SECONDS),
+            new IsEqual<>(false)
+        );
+    }
+}

--- a/src/test/java/com/artipie/asto/memory/package-info.java
+++ b/src/test/java/com/artipie/asto/memory/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Tests for in memory storage related classes.
+ *
+ * @since 0.15
+ */
+package com.artipie.asto.memory;
+


### PR DESCRIPTION
Closes #153 
Reason for example code to fail is endless `Publisher`. It is getting read inside `synchronized`, so read operation cannot obtain the lock.
Fixed it by  bringing content reading outside of synchronized section + got rid of other Single.blockingGet() usage because it creates errors in Vert.x environment