### PR TITLE
#163 - S3 storage saves value without reading it twice

### DIFF
--- a/src/test/java/com/artipie/asto/S3StorageTest.java
+++ b/src/test/java/com/artipie/asto/S3StorageTest.java
@@ -49,7 +49,10 @@ import org.hamcrest.collection.IsEmptyIterable;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -59,6 +62,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
  * Tests for {@link S3Storage}.
  *
  * @since 0.15
+ * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (3 lines)
  */
 @SuppressWarnings("PMD.TooManyMethods")
@@ -92,17 +96,19 @@ class S3StorageTest {
     }
 
     @Test
+    @Timeout(5)
     void shouldUploadObjectWhenSaveContentOfUnknownSize(final AmazonS3 client) throws Exception {
         final byte[] data = "data?".getBytes();
         final String key = "unknown/size";
         this.storage().save(
             new Key.From(key),
-            new Content.From(Flowable.just(ByteBuffer.wrap(data)))
+            new Content.From(new OneOffPublisher(ByteBuffer.wrap(data)))
         ).join();
         MatcherAssert.assertThat(this.download(client, key), Matchers.equalTo(data));
     }
 
     @Test
+    @Timeout(15)
     void shouldUploadObjectWhenSaveLargeContent(final AmazonS3 client) throws Exception {
         final int size = 20 * 1024 * 1024;
         final byte[] data = new byte[size];
@@ -110,7 +116,7 @@ class S3StorageTest {
         final String key = "big/data";
         this.storage().save(
             new Key.From(key),
-            new Content.From(Flowable.just(ByteBuffer.wrap(data)))
+            new Content.From(new OneOffPublisher(ByteBuffer.wrap(data)))
         ).join();
         MatcherAssert.assertThat(this.download(client, key), Matchers.equalTo(data));
     }
@@ -251,5 +257,36 @@ class S3StorageTest {
             )
             .build();
         return new S3Storage(client, this.bucket);
+    }
+
+    /**
+     * Publisher that produces value only once for first subscription.
+     *
+     * @since 0.18
+     */
+    private static class OneOffPublisher implements Publisher<ByteBuffer> {
+
+        /**
+         * Data for subscriber.
+         */
+        private final ByteBuffer data;
+
+        /**
+         * Flag for completion.
+         */
+        private volatile boolean complete;
+
+        OneOffPublisher(final ByteBuffer data) {
+            this.data = data;
+        }
+
+        @Override
+        public void subscribe(final Subscriber<? super ByteBuffer> subscriber) {
+            if (!this.complete) {
+                this.complete = true;
+                subscriber.onNext(this.data);
+                subscriber.onComplete();
+            }
+        }
     }
 }

--- a/src/test/java/com/artipie/asto/s3/S3StorageTest.java
+++ b/src/test/java/com/artipie/asto/s3/S3StorageTest.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.artipie.asto;
+package com.artipie.asto.s3;
 
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.amazonaws.services.s3.AmazonS3;
@@ -29,8 +29,9 @@ import com.amazonaws.services.s3.model.ListMultipartUploadsRequest;
 import com.amazonaws.services.s3.model.MultipartUpload;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
 import com.artipie.asto.blocking.BlockingStorage;
-import com.artipie.asto.s3.S3Storage;
 import com.google.common.io.ByteStreams;
 import io.reactivex.Flowable;
 import java.io.ByteArrayInputStream;
@@ -262,7 +263,7 @@ class S3StorageTest {
     /**
      * Publisher that produces value only once for first subscription.
      *
-     * @since 0.18
+     * @since 0.19
      */
     private static class OneOffPublisher implements Publisher<ByteBuffer> {
 

--- a/src/test/java/com/artipie/asto/s3/S3StorageTest.java
+++ b/src/test/java/com/artipie/asto/s3/S3StorageTest.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -275,16 +276,16 @@ class S3StorageTest {
         /**
          * Flag for completion.
          */
-        private volatile boolean complete;
+        private final AtomicBoolean complete;
 
         OneOffPublisher(final ByteBuffer data) {
             this.data = data;
+            this.complete = new AtomicBoolean(false);
         }
 
         @Override
         public void subscribe(final Subscriber<? super ByteBuffer> subscriber) {
-            if (!this.complete) {
-                this.complete = true;
+            if (!this.complete.getAndSet(true)) {
                 subscriber.onNext(this.data);
                 subscriber.onComplete();
             }


### PR DESCRIPTION
Part of #163 
Added tests to illustrate the problem and adds caching for content being saved by `S3Storage`.
This is not ideal solution and it is needed to change code so it won't cache all content, but only data up to `MIN_MULTIPART` size in bytes.