### PR TITLE
Fix ls logging

### DIFF
--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -113,7 +113,7 @@ public final class FileStorage implements Storage {
                 Logger.info(
                     this,
                     "Found %d objects by the prefix \"%s\" in %s by %s: %s",
-                    keys.size(), prefix, this.dir, path, keys
+                    keys.size(), prefix.string(), this.dir, path, keys
                 );
                 return keys;
             }).to(SingleInterop.get()).toCompletableFuture();


### PR DESCRIPTION
That is how the log message looks now:
```
[INFO] vert.x-eventloop-thread-3 com.artipie.asto.fs.FileStorage: Found 2 objects by the prefix "com.artipie.asto.Key$From@66f262b" in temp-gem-index by temp-gem-index/quick: []
```

the actual prefix name should be in the log