### PR TITLE
Revert made changes with FileSystem + Vert.x 3.9.1 bump

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-jdk-${{ matrix.java }}-mvn-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-jdk-${{ matrix.java }}-mvn-
       - name: Build it with Maven
-        run: mvn clean verify -B -Pqulice
+        run: mvn -B verify -Pqulice

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,27 @@ SOFTWARE.
       <artifactId>jcabi-log</artifactId>
       <version>0.18.1</version>
     </dependency>
+    <!-- Vert.x dependencies -->
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-rx-java</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-reactive-streams</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-rx-java2</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
     <!-- RxJava -->
     <dependency>
       <groupId>com.github.akarnokd</groupId>
@@ -103,11 +124,6 @@ SOFTWARE.
       <artifactId>rxjava2-extensions</artifactId>
       <version>0.20.10</version>
     </dependency>
-    <dependency>
-      <groupId>wtf.g4s8</groupId>
-      <artifactId>rio</artifactId>
-      <version>0.1.6</version>
-    </dependency>
     <!-- S3 client -->
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
@@ -117,6 +133,18 @@ SOFTWARE.
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.6.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ SOFTWARE.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <properties>
-    <vertx.version>3.9.0</vertx.version>
+    <vertx.version>3.9.1</vertx.version>
   </properties>
   <parent>
     <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -28,25 +28,21 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.Transaction;
 import com.jcabi.log.Logger;
-import java.io.IOException;
-import java.io.UncheckedIOException;
+import hu.akarnokd.rxjava2.interop.CompletableInterop;
+import hu.akarnokd.rxjava2.interop.SingleInterop;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.vertx.reactivex.core.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import wtf.g4s8.rio.file.File;
 
 /**
  * Simple storage, in files.
@@ -61,54 +57,34 @@ public final class FileStorage implements Storage {
     private final Path dir;
 
     /**
-     * IO executor service.
+     * The Vert.x file system.
      */
-    private final ExecutorService exec;
+    private final FileSystem fls;
 
     /**
      * Ctor.
+     *
      * @param path The path to the dir
-     * @param nothing Just for compatibility
-     * @deprecated Use {@link FileStorage#FileStorage(Path)} ctor instead.
+     * @param fls The file system
      */
-    @Deprecated
-    @SuppressWarnings("PMD.UnusedFormalParameter")
-    public FileStorage(final Path path, final Object nothing) {
-        this(path);
-    }
-
-    /**
-     * Ctor.
-     * @param path File path
-     */
-    public FileStorage(final Path path) {
-        this(path, ThreadPool.EXEC);
-    }
-
-    /**
-     * Ctor.
-     * @param path The path to the dir
-     * @param exec IO Executor service
-     */
-    public FileStorage(final Path path, final ExecutorService exec) {
+    public FileStorage(final Path path, final FileSystem fls) {
         this.dir = path;
-        this.exec = exec;
+        this.fls = fls;
     }
 
     @Override
     public CompletableFuture<Boolean> exists(final Key key) {
-        return CompletableFuture.supplyAsync(
+        return Single.fromCallable(
             () -> {
                 final Path path = this.path(key);
                 return Files.exists(path) && !Files.isDirectory(path);
-            },
-            this.exec
-        );
+            }
+        ).to(SingleInterop.get()).toCompletableFuture();
     }
 
     @Override
     public CompletableFuture<Collection<Key>> list(final Key prefix) {
-        return CompletableFuture.supplyAsync(
+        return Single.fromCallable(
             () -> {
                 final Path path = this.path(prefix);
                 final Collection<Key> keys;
@@ -119,22 +95,18 @@ public final class FileStorage implements Storage {
                     } else {
                         dirnamelen = path.toString().length() - prefix.string().length();
                     }
-                    try {
-                        keys = Files.walk(path)
-                            .filter(Files::isRegularFile)
-                            .map(Path::toString)
-                            .map(p -> p.substring(dirnamelen))
-                            .map(
-                                s -> s.split(
-                                    FileSystems.getDefault().getSeparator().replace("\\", "\\\\")
-                                )
+                    keys = Files.walk(path)
+                        .filter(Files::isRegularFile)
+                        .map(Path::toString)
+                        .map(p -> p.substring(dirnamelen))
+                        .map(
+                            s -> s.split(
+                                FileSystems.getDefault().getSeparator().replace("\\", "\\\\")
                             )
-                            .map(Key.From::new)
-                            .sorted(Comparator.comparing(Key.From::string))
-                            .collect(Collectors.toList());
-                    } catch (final IOException iex) {
-                        throw new UncheckedIOException(iex);
-                    }
+                        )
+                        .map(Key.From::new)
+                        .sorted(Comparator.comparing(Key.From::string))
+                        .collect(Collectors.toList());
                 } else {
                     keys = Collections.emptyList();
                 }
@@ -144,87 +116,65 @@ public final class FileStorage implements Storage {
                     keys.size(), prefix.string(), this.dir, path, keys
                 );
                 return keys;
-            },
-            this.exec
-        );
+            }).to(SingleInterop.get()).toCompletableFuture();
     }
 
     @Override
     public CompletableFuture<Void> save(final Key key, final Content content) {
-        return CompletableFuture.supplyAsync(
+        return Single.fromCallable(
             () -> {
                 final Path file = this.path(key);
-                try {
-                    Files.createDirectories(file.getParent());
-                } catch (final IOException iex) {
-                    throw new UncheckedIOException(iex);
-                }
+                Files.createDirectories(file.getParent());
                 return file;
-            },
-            this.exec
-        ).thenCompose(
-            path -> new File(path).write(
-                content, this.exec,
-                StandardOpenOption.WRITE,
-                StandardOpenOption.CREATE,
-                StandardOpenOption.TRUNCATE_EXISTING
-            )
-        );
+            })
+            .flatMapCompletable(
+                file -> new RxFile(file, this.fls).save(Flowable.fromPublisher(content))
+            ).to(CompletableInterop.await())
+            .<Void>thenApply(o -> null)
+            .toCompletableFuture();
     }
 
     @Override
     public CompletableFuture<Void> move(final Key source, final Key destination) {
-        return CompletableFuture.supplyAsync(
+        return Single.fromCallable(
             () -> {
                 final Path dest = this.path(destination);
                 dest.getParent().toFile().mkdirs();
                 return dest;
-            },
-            this.exec
-        ).thenAccept(
-            dst -> {
-                try {
-                    Files.move(this.path(source), dst, StandardCopyOption.REPLACE_EXISTING);
-                } catch (final IOException iex) {
-                    throw new UncheckedIOException(iex);
-                }
-            }
-        );
+            })
+            .flatMapCompletable(
+                dest -> new RxFile(this.path(source), this.fls).move(dest)
+            )
+            .to(CompletableInterop.await())
+            .<Void>thenApply(file -> null)
+            .toCompletableFuture();
     }
 
     @Override
     public CompletableFuture<Void> delete(final Key key) {
-        return CompletableFuture.runAsync(
-            () -> {
-                try {
-                    Files.delete(this.path(key));
-                } catch (final IOException iex) {
-                    throw new UncheckedIOException(iex);
-                }
-            },
-            this.exec
-        );
+        return new RxFile(this.path(key), this.fls)
+            .delete()
+            .to(CompletableInterop.await())
+            .toCompletableFuture()
+            .thenCompose(ignored -> CompletableFuture.allOf());
     }
 
     @Override
     public CompletableFuture<Long> size(final Key key) {
-        return CompletableFuture.supplyAsync(
-            () -> {
-                try {
-                    return Files.size(this.path(key));
-                } catch (final IOException iex) {
-                    throw new UncheckedIOException(iex);
-                }
-            },
-            this.exec
-        );
+        return new RxFile(this.path(key), this.fls)
+            .size()
+            .to(SingleInterop.get())
+            .toCompletableFuture();
     }
 
     @Override
     public CompletableFuture<Content> value(final Key key) {
-        return this.size(key).thenApply(
-            size -> new Content.From(size, new File(this.path(key)).content(this.exec))
-        );
+        return CompletableFuture.supplyAsync(() -> new RxFile(this.path(key), this.fls))
+            .thenCompose(
+                file -> file.size().<Content>map(size -> new Content.From(size, file.flow()))
+                    .to(SingleInterop.get())
+                    .toCompletableFuture()
+            );
     }
 
     @Override
@@ -240,51 +190,5 @@ public final class FileStorage implements Storage {
      */
     private Path path(final Key key) {
         return Paths.get(this.dir.toString(), key.string());
-    }
-
-    /**
-     * Thread factory and lazy executor holder.
-     * @since 0.19
-     */
-    private static final class ThreadPool implements ThreadFactory {
-
-        /**
-         * Lazy instance of thread pool.
-         */
-        static final ExecutorService EXEC = Executors.newFixedThreadPool(
-            Runtime.getRuntime().availableProcessors(),
-            new ThreadPool()
-        );
-
-        /**
-         * Counter.
-         */
-        private final AtomicInteger cnt;
-
-        /**
-         * Default ctor.
-         */
-        private ThreadPool() {
-            this(new AtomicInteger());
-        }
-
-        /**
-         * Primary ctor.
-         * @param cnt Thread counter
-         */
-        private ThreadPool(final AtomicInteger cnt) {
-            this.cnt = cnt;
-        }
-
-        @Override
-        public Thread newThread(final Runnable runnable) {
-            return new Thread(
-                runnable,
-                String.format(
-                    "%s-%d",
-                    FileStorage.class.getSimpleName(), this.cnt.incrementAndGet()
-                )
-            );
-        }
     }
 }

--- a/src/main/java/com/artipie/asto/fs/RxFile.java
+++ b/src/main/java/com/artipie/asto/fs/RxFile.java
@@ -23,21 +23,18 @@
  */
 package com.artipie.asto.fs;
 
-import hu.akarnokd.rxjava2.interop.CompletableInterop;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
-import io.reactivex.subjects.CompletableSubject;
-import io.reactivex.subjects.SingleSubject;
-import java.io.IOException;
+import io.vertx.core.file.CopyOptions;
+import io.vertx.core.file.OpenOptions;
+import io.vertx.reactivex.core.Promise;
+import io.vertx.reactivex.core.file.FileSystem;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import wtf.g4s8.rio.file.File;
 
 /**
  * The reactive file allows you to perform read and write operations via {@link RxFile#flow()}
@@ -55,26 +52,18 @@ public class RxFile {
     private final Path file;
 
     /**
-     * IO executor.
+     * The file system.
      */
-    private final ExecutorService exec;
+    private final FileSystem fls;
 
     /**
      * Ctor.
-     * @param file File path
+     * @param file The wrapped file.
+     * @param fls The file system.
      */
-    public RxFile(final Path file) {
-        this(file, Executors.newCachedThreadPool());
-    }
-
-    /**
-     * Ctor.
-     * @param file The wrapped file
-     * @param exec IO executor
-     */
-    public RxFile(final Path file, final ExecutorService exec) {
+    public RxFile(final Path file, final FileSystem fls) {
         this.file = file;
-        this.exec = exec;
+        this.fls = fls;
     }
 
     /**
@@ -82,7 +71,34 @@ public class RxFile {
      * @return A flow of bytes
      */
     public Flowable<ByteBuffer> flow() {
-        return Flowable.fromPublisher(new File(this.file).content(this.exec));
+        return this.fls.rxOpen(
+            this.file.toString(),
+            new OpenOptions()
+                .setRead(true)
+                .setWrite(false)
+                .setCreate(false)
+        )
+            .flatMapPublisher(
+                asyncFile -> {
+                    final Promise<Void> promise = Promise.promise();
+                    final Completable completable = Completable.create(
+                        emitter ->
+                            promise.future().onComplete(
+                                event -> {
+                                    if (event.succeeded()) {
+                                        emitter.onComplete();
+                                    } else {
+                                        emitter.onError(event.cause());
+                                    }
+                                }
+                            )
+                    );
+                    return asyncFile.toFlowable().map(
+                        buffer -> ByteBuffer.wrap(buffer.getBytes())
+                    ).doOnTerminate(() -> asyncFile.rxClose().subscribe(promise::complete))
+                        .mergeWith(completable);
+                }
+            );
     }
 
     /**
@@ -92,13 +108,23 @@ public class RxFile {
      * @return Completion or error signal
      */
     public Completable save(final Flowable<ByteBuffer> flow) {
-        return CompletableInterop.fromFuture(
-            new File(this.file).write(
-                flow,
-                this.exec,
-                StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+        return Single.fromCallable(
+            () -> FileChannel.open(
+                this.file,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE,
                 StandardOpenOption.TRUNCATE_EXISTING
             )
+        ).flatMapCompletable(
+            chan -> flow.reduce(
+                chan,
+                (out, buf) -> {
+                    while (buf.hasRemaining()) {
+                        out.write(buf);
+                    }
+                    return out;
+                }
+            ).ignoreElement().doOnTerminate(chan::close)
         );
     }
 
@@ -109,18 +135,11 @@ public class RxFile {
      * @return Completion or error signal
      */
     public Completable move(final Path target) {
-        final CompletableSubject res = CompletableSubject.create();
-        this.exec.submit(
-            () -> {
-                try {
-                    Files.move(this.file, target, StandardCopyOption.REPLACE_EXISTING);
-                    res.onComplete();
-                } catch (final IOException iex) {
-                    res.onError(iex);
-                }
-            }
+        return this.fls.rxMove(
+            this.file.toString(),
+            target.toString(),
+            new CopyOptions().setReplaceExisting(true)
         );
-        return res;
     }
 
     /**
@@ -129,18 +148,7 @@ public class RxFile {
      * @return Completion or error signal
      */
     public Completable delete() {
-        final CompletableSubject res = CompletableSubject.create();
-        this.exec.submit(
-            () -> {
-                try {
-                    Files.delete(this.file);
-                    res.onComplete();
-                } catch (final IOException iex) {
-                    res.onError(iex);
-                }
-            }
-        );
-        return res;
+        return this.fls.rxDelete(this.file.toString());
     }
 
     /**
@@ -149,16 +157,6 @@ public class RxFile {
      * @return File size in bytes.
      */
     public Single<Long> size() {
-        final SingleSubject<Long> res = SingleSubject.create();
-        this.exec.submit(
-            () -> {
-                try {
-                    res.onSuccess(Files.size(this.file));
-                } catch (final IOException iex) {
-                    res.onError(iex);
-                }
-            }
-        );
-        return res;
+        return Single.fromCallable(() -> Files.size(this.file));
     }
 }

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -25,23 +25,23 @@ package com.artipie.asto;
 
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.fs.FileStorage;
-import hu.akarnokd.rxjava2.interop.SingleInterop;
+import io.reactivex.Emitter;
 import io.reactivex.Flowable;
+import io.reactivex.functions.Consumer;
 import io.vertx.reactivex.core.Vertx;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.MessageDigest;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import org.apache.commons.codec.binary.Hex;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -54,26 +54,24 @@ import org.junit.jupiter.api.io.TempDir;
 final class FileStorageTest {
 
     /**
-     * Vert.x used to create tested FileStorage.
-     */
-    private Vertx vertx;
-
-    /**
      * File storage used in tests.
      */
     private FileStorage storage;
 
+    /**
+     * The Vert.x.
+     */
+    private Vertx vertx;
+
     @BeforeEach
-    void setUp(@TempDir final Path tmp) {
+    void before(@TempDir final Path tmp) {
         this.vertx = Vertx.vertx();
         this.storage = new FileStorage(tmp, this.vertx.fileSystem());
     }
 
     @AfterEach
-    void tearDown() {
-        if (this.vertx != null) {
-            this.vertx.rxClose().blockingAwait();
-        }
+    void after(@TempDir final Path tmp) {
+        this.vertx.close();
     }
 
     @Test
@@ -94,7 +92,7 @@ final class FileStorageTest {
     }
 
     @Test
-    void saveOverwrites() {
+    void saveOverwrites() throws Exception {
         final byte[] original = "1".getBytes(StandardCharsets.UTF_8);
         final byte[] updated = "2".getBytes(StandardCharsets.UTF_8);
         final BlockingStorage blocking = new BlockingStorage(this.storage);
@@ -108,7 +106,19 @@ final class FileStorageTest {
     }
 
     @Test
-    void blockingWrapperWorks() {
+    void readsTheSize() throws Exception {
+        final BlockingStorage bsto = new BlockingStorage(this.storage);
+        final Key key = new Key.From("withSize");
+        bsto.save(key, new byte[]{0x00, 0x00, 0x00});
+        MatcherAssert.assertThat(
+            bsto.size(key),
+            // @checkstyle MagicNumberCheck (1 line)
+            Matchers.equalTo(3L)
+        );
+    }
+
+    @Test
+    void blockingWrapperWorks() throws Exception {
         final BlockingStorage blocking = new BlockingStorage(this.storage);
         final String content = "hello, friend!";
         final Key key = new Key.From("t", "y", "testb.deb");
@@ -123,7 +133,7 @@ final class FileStorageTest {
     }
 
     @Test
-    void move() {
+    void move() throws Exception {
         final byte[] data = "data".getBytes(StandardCharsets.UTF_8);
         final BlockingStorage blocking = new BlockingStorage(this.storage);
         final Key source = new Key.From("from");
@@ -138,52 +148,65 @@ final class FileStorageTest {
 
     @Test
     @EnabledIfSystemProperty(named = "test.storage.file.huge", matches = "true|on")
-    void saveAndLoadHugeFiles() throws Exception {
-        // @checkstyle MagicNumberCheck (30 lines)
-        // @checkstyle MethodBodyCommentsCheck (30 lines)
-        final Key key = new Key.From("huge");
-        // one 8KB fragment of repeated sequence of byte ranges 0x00..0xFF
-        final ByteBuffer fragment = ByteBuffer.wrap(
-            new ByteArray(
-                IntStream.range(0, 4 * 8).flatMap(
-                    cnt -> IntStream.range(0, 256)
-                ).mapToObj(x -> (byte) x)
-                    .collect(Collectors.toList())
-            ).primitiveBytes()
-        );
-        // 1 GB of 8KB byte fragments
-        final AtomicLong cnt = new AtomicLong(131_072);
-        this.storage.save(
-            key,
+    @Timeout(1L)
+    void saveAndLoadHugeFiles(@TempDir final Path tmp) throws Exception {
+        final String name = "huge";
+        new FileStorage(tmp, this.vertx.fileSystem()).save(
+            new Key.From(name),
             new Content.From(
-                Flowable.generate(
-                    // @checkstyle ReturnCountCheck (10 lines)
-                    emitter -> {
-                        if (cnt.decrementAndGet() == 0) {
-                            emitter.onComplete();
-                            return;
-                        }
-                        if (cnt.get() == 0) {
-                            return;
-                        }
-                        emitter.onNext(fragment.slice());
-                    }
-                )
+                // @checkstyle MagicNumberCheck (1 line)
+                Flowable.generate(new WriteTestSource(1024 * 8, 1024 * 1024 / 8))
             )
         ).get();
-        final String hash = this.storage.value(key).thenCompose(
-            content -> Flowable.fromPublisher(content).reduceWith(
-                () -> MessageDigest.getInstance("SHA256"),
-                (digest, buf) -> {
-                    digest.update(buf);
-                    return digest;
-                }
-            ).map(digest -> new String(Hex.encodeHex(digest.digest())))
-                .to(SingleInterop.get())
-        ).get();
         MatcherAssert.assertThat(
-            hash,
-            new IsEqual<>("13b0e1029eae62b2cde3e918d384ce704319a1eca1cf268b962cb34dbbab04e4")
+            Files.size(tmp.resolve(name)),
+            // @checkstyle MagicNumberCheck (1 line)
+            Matchers.equalTo(1024L * 1024 * 1024)
         );
+    }
+
+    /**
+     * Provider of byte buffers for write test.
+     * @since 0.2
+     */
+    private static final class WriteTestSource implements Consumer<Emitter<ByteBuffer>> {
+
+        /**
+         * Counter.
+         */
+        private final AtomicInteger cnt;
+
+        /**
+         * Amount of buffers.
+         */
+        private final int length;
+
+        /**
+         * Buffer size.
+         */
+        private final int size;
+
+        /**
+         * New test source.
+         * @param size Buffer size
+         * @param length Amount of buffers
+         */
+        WriteTestSource(final int size, final int length) {
+            this.cnt = new AtomicInteger();
+            this.size = size;
+            this.length = length;
+        }
+
+        @Override
+        public void accept(final Emitter<ByteBuffer> src) {
+            final int val = this.cnt.getAndIncrement();
+            if (val < this.length) {
+                final byte[] data = new byte[this.size];
+                Arrays.fill(data, (byte) val);
+                src.onNext(ByteBuffer.wrap(data));
+            } else {
+                src.onComplete();
+            }
+        }
     }
 }

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -25,21 +25,23 @@ package com.artipie.asto;
 
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.fs.FileStorage;
-import io.reactivex.Emitter;
+import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Flowable;
-import io.reactivex.functions.Consumer;
+import io.vertx.reactivex.core.Vertx;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.security.MessageDigest;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.commons.codec.binary.Hex;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -52,13 +54,26 @@ import org.junit.jupiter.api.io.TempDir;
 final class FileStorageTest {
 
     /**
+     * Vert.x used to create tested FileStorage.
+     */
+    private Vertx vertx;
+
+    /**
      * File storage used in tests.
      */
     private FileStorage storage;
 
     @BeforeEach
     void setUp(@TempDir final Path tmp) {
-        this.storage = new FileStorage(tmp);
+        this.vertx = Vertx.vertx();
+        this.storage = new FileStorage(tmp, this.vertx.fileSystem());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (this.vertx != null) {
+            this.vertx.rxClose().blockingAwait();
+        }
     }
 
     @Test
@@ -79,7 +94,7 @@ final class FileStorageTest {
     }
 
     @Test
-    void saveOverwrites() throws Exception {
+    void saveOverwrites() {
         final byte[] original = "1".getBytes(StandardCharsets.UTF_8);
         final byte[] updated = "2".getBytes(StandardCharsets.UTF_8);
         final BlockingStorage blocking = new BlockingStorage(this.storage);
@@ -93,19 +108,7 @@ final class FileStorageTest {
     }
 
     @Test
-    void readsTheSize() throws Exception {
-        final BlockingStorage bsto = new BlockingStorage(this.storage);
-        final Key key = new Key.From("withSize");
-        bsto.save(key, new byte[]{0x00, 0x00, 0x00});
-        MatcherAssert.assertThat(
-            bsto.size(key),
-            // @checkstyle MagicNumberCheck (1 line)
-            Matchers.equalTo(3L)
-        );
-    }
-
-    @Test
-    void blockingWrapperWorks() throws Exception {
+    void blockingWrapperWorks() {
         final BlockingStorage blocking = new BlockingStorage(this.storage);
         final String content = "hello, friend!";
         final Key key = new Key.From("t", "y", "testb.deb");
@@ -120,7 +123,7 @@ final class FileStorageTest {
     }
 
     @Test
-    void move() throws Exception {
+    void move() {
         final byte[] data = "data".getBytes(StandardCharsets.UTF_8);
         final BlockingStorage blocking = new BlockingStorage(this.storage);
         final Key source = new Key.From("from");
@@ -135,65 +138,52 @@ final class FileStorageTest {
 
     @Test
     @EnabledIfSystemProperty(named = "test.storage.file.huge", matches = "true|on")
-    @Timeout(1L)
-    void saveAndLoadHugeFiles(@TempDir final Path tmp) throws Exception {
-        final String name = "huge";
-        new FileStorage(tmp).save(
-            new Key.From(name),
+    void saveAndLoadHugeFiles() throws Exception {
+        // @checkstyle MagicNumberCheck (30 lines)
+        // @checkstyle MethodBodyCommentsCheck (30 lines)
+        final Key key = new Key.From("huge");
+        // one 8KB fragment of repeated sequence of byte ranges 0x00..0xFF
+        final ByteBuffer fragment = ByteBuffer.wrap(
+            new ByteArray(
+                IntStream.range(0, 4 * 8).flatMap(
+                    cnt -> IntStream.range(0, 256)
+                ).mapToObj(x -> (byte) x)
+                    .collect(Collectors.toList())
+            ).primitiveBytes()
+        );
+        // 1 GB of 8KB byte fragments
+        final AtomicLong cnt = new AtomicLong(131_072);
+        this.storage.save(
+            key,
             new Content.From(
-                // @checkstyle MagicNumberCheck (1 line)
-                Flowable.generate(new WriteTestSource(1024 * 8, 1024 * 1024 / 8))
+                Flowable.generate(
+                    // @checkstyle ReturnCountCheck (10 lines)
+                    emitter -> {
+                        if (cnt.decrementAndGet() == 0) {
+                            emitter.onComplete();
+                            return;
+                        }
+                        if (cnt.get() == 0) {
+                            return;
+                        }
+                        emitter.onNext(fragment.slice());
+                    }
+                )
             )
         ).get();
+        final String hash = this.storage.value(key).thenCompose(
+            content -> Flowable.fromPublisher(content).reduceWith(
+                () -> MessageDigest.getInstance("SHA256"),
+                (digest, buf) -> {
+                    digest.update(buf);
+                    return digest;
+                }
+            ).map(digest -> new String(Hex.encodeHex(digest.digest())))
+                .to(SingleInterop.get())
+        ).get();
         MatcherAssert.assertThat(
-            Files.size(tmp.resolve(name)),
-            // @checkstyle MagicNumberCheck (1 line)
-            Matchers.equalTo(1024L * 1024 * 1024)
+            hash,
+            new IsEqual<>("13b0e1029eae62b2cde3e918d384ce704319a1eca1cf268b962cb34dbbab04e4")
         );
-    }
-
-    /**
-     * Provider of byte buffers for write test.
-     * @since 0.2
-     */
-    private static final class WriteTestSource implements Consumer<Emitter<ByteBuffer>> {
-
-        /**
-         * Counter.
-         */
-        private final AtomicInteger cnt;
-
-        /**
-         * Amount of buffers.
-         */
-        private final int length;
-
-        /**
-         * Buffer size.
-         */
-        private final int size;
-
-        /**
-         * New test source.
-         * @param size Buffer size
-         * @param length Amount of buffers
-         */
-        WriteTestSource(final int size, final int length) {
-            this.cnt = new AtomicInteger();
-            this.size = size;
-            this.length = length;
-        }
-
-        @Override
-        public void accept(final Emitter<ByteBuffer> src) {
-            final int val = this.cnt.getAndIncrement();
-            if (val < this.length) {
-                final byte[] data = new byte[this.size];
-                Arrays.fill(data, (byte) val);
-                src.onNext(ByteBuffer.wrap(data));
-            } else {
-                src.onComplete();
-            }
-        }
     }
 }

--- a/src/test/java/com/artipie/asto/RxFileTest.java
+++ b/src/test/java/com/artipie/asto/RxFileTest.java
@@ -34,8 +34,8 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.io.TempDir;
 final class RxFileTest {
 
     @Test
+    @Timeout(1)
     public void rxFileFlowWorks(@TempDir final Path tmp) throws IOException {
         final Vertx vertx = Vertx.vertx();
         final String hello = "hello-world";
@@ -66,6 +67,7 @@ final class RxFileTest {
     }
 
     @Test
+    @Timeout(1)
     public void rxFileTruncatesExistingFile(@TempDir final Path tmp) throws Exception {
         final Vertx vertx = Vertx.vertx();
         final String one = "one";
@@ -81,26 +83,27 @@ final class RxFileTest {
     }
 
     // @checkstyle MagicNumberCheck (1 line)
-    @RepeatedTest(100)
+    @Test
+    @Timeout(1)
     public void rxFileSaveWorks(@TempDir final Path tmp) throws IOException {
         final Vertx vertx = Vertx.vertx();
         final String hello = "hello-world!!!";
         final Path temp = tmp.resolve("saved.txt");
-        new RxFile(temp, vertx.fileSystem())
-            .save(
-                Flowable.fromArray(new ByteArray(hello.getBytes()).boxedBytes()).map(
-                    aByte -> {
-                        final byte[] bytes = new byte[1];
-                        bytes[0] = aByte;
-                        return ByteBuffer.wrap(bytes);
-                    }
-                )
-            ).blockingAwait();
+        new RxFile(temp, vertx.fileSystem()).save(
+            Flowable.fromArray(new ByteArray(hello.getBytes()).boxedBytes()).map(
+                aByte -> {
+                    final byte[] bytes = new byte[1];
+                    bytes[0] = aByte;
+                    return ByteBuffer.wrap(bytes);
+                }
+            )
+        ).blockingAwait();
         MatcherAssert.assertThat(new String(Files.readAllBytes(temp)), Matchers.equalTo(hello));
         vertx.close();
     }
 
-    @Test()
+    @Test
+    @Timeout(1)
     public void rxFileSizeWorks(@TempDir final Path tmp) throws IOException {
         final Vertx vertx = Vertx.vertx();
         final byte[] data = "012345".getBytes();

--- a/src/test/java/com/artipie/asto/StorageDeleteTest.java
+++ b/src/test/java/com/artipie/asto/StorageDeleteTest.java
@@ -58,7 +58,7 @@ public final class StorageDeleteTest {
     }
 
     @TestTemplate
-    void shouldFailToDeleteParentOfSavedKey(final Storage storage) throws Exception {
+    void shouldFailToDeleteParentOfSavedKey(final Storage storage) {
         final Key parent = new Key.From("shouldFailToDeleteParentOfSavedKey");
         final Key key = new Key.From(parent, "child");
         final byte[] content = "content".getBytes();

--- a/src/test/java/com/artipie/asto/StorageExtension.java
+++ b/src/test/java/com/artipie/asto/StorageExtension.java
@@ -29,6 +29,7 @@ import com.artipie.asto.fs.FileStorage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.s3.S3Storage;
 import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.core.file.FileSystem;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -70,22 +71,18 @@ final class StorageExtension
         .build();
 
     /**
-     * Vert.x instance to use in tests.
+     * Vert.x file System.
      */
-    private Vertx vertx;
+    private final FileSystem fls = Vertx.vertx().fileSystem();
 
     @Override
     public void beforeAll(final ExtensionContext extension) {
         this.mock.beforeAll(extension);
-        this.vertx = Vertx.vertx();
     }
 
     @Override
     public void afterAll(final ExtensionContext extension) {
         this.mock.afterAll(extension);
-        if (this.vertx != null) {
-            this.vertx.rxClose().blockingAwait();
-        }
     }
 
     @Override
@@ -102,10 +99,7 @@ final class StorageExtension
                 new InMemoryStorage(),
                 new InMemoryStorage().transaction(Collections.emptyList()).get(),
                 this.s3Storage(),
-                new FileStorage(
-                    Files.createTempDirectory("junit"),
-                    this.vertx.fileSystem()
-                )
+                new FileStorage(Files.createTempDirectory("junit"), this.fls)
             );
         } catch (final InterruptedException | ExecutionException | IOException ex) {
             throw new IllegalStateException("Failed to generate storage", ex);

--- a/src/test/java/com/artipie/asto/StorageListTest.java
+++ b/src/test/java/com/artipie/asto/StorageListTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public final class StorageListTest {
 
     @TestTemplate
-    void shouldListNoKeysWhenEmpty(final Storage storage) throws Exception {
+    void shouldListNoKeysWhenEmpty(final Storage storage) {
         final BlockingStorage blocking = new BlockingStorage(storage);
         final Collection<String> keys = blocking.list(new Key.From("a", "b"))
             .stream()
@@ -51,7 +51,7 @@ public final class StorageListTest {
     }
 
     @TestTemplate
-    void shouldListKeysInOrder(final Storage storage) throws Exception {
+    void shouldListKeysInOrder(final Storage storage) {
         final byte[] data = "some data!".getBytes();
         final BlockingStorage blocking = new BlockingStorage(storage);
         blocking.save(new Key.From("1"), data);

--- a/src/test/java/com/artipie/asto/StorageMoveTest.java
+++ b/src/test/java/com/artipie/asto/StorageMoveTest.java
@@ -28,7 +28,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -40,8 +39,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public final class StorageMoveTest {
 
     @TestTemplate
-    @Timeout(1)
-    void shouldMove(final Storage storage) throws Exception {
+    void shouldMove(final Storage storage) {
         final BlockingStorage blocking = new BlockingStorage(storage);
         final byte[] data = "source".getBytes();
         final Key source = new Key.From("shouldMove-source");
@@ -52,8 +50,7 @@ public final class StorageMoveTest {
     }
 
     @TestTemplate
-    @Timeout(1)
-    void shouldMoveWhenDestinationExists(final Storage storage) throws Exception {
+    void shouldMoveWhenDestinationExists(final Storage storage) {
         final BlockingStorage blocking = new BlockingStorage(storage);
         final byte[] data = "source data".getBytes();
         final Key source = new Key.From("shouldMoveWhenDestinationExists-source");
@@ -68,8 +65,7 @@ public final class StorageMoveTest {
     }
 
     @TestTemplate
-    @Timeout(1)
-    void shouldFailToMoveAbsentValue(final Storage storage) throws Exception {
+    void shouldFailToMoveAbsentValue(final Storage storage) {
         final BlockingStorage blocking = new BlockingStorage(storage);
         final Key source = new Key.From("shouldFailToMoveAbsentValue-source");
         final Key destination = new Key.From("shouldFailToMoveAbsentValue-destination");

--- a/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
+++ b/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
@@ -30,7 +30,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -42,8 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public final class StorageSaveAndLoadTest {
 
     @TestTemplate
-    @Timeout(1)
-    void shouldSave(final Storage storage) throws Exception {
+    void shouldSave(final Storage storage) {
         final BlockingStorage blocking = new BlockingStorage(storage);
         final byte[] data = "0".getBytes();
         final Key key = new Key.From("shouldSave");
@@ -55,7 +53,6 @@ public final class StorageSaveAndLoadTest {
     }
 
     @TestTemplate
-    @Timeout(1)
     void shouldSaveFromMultipleBuffers(final Storage storage) throws Exception {
         final Key key = new Key.From("shouldSaveFromMultipleBuffers");
         storage.save(
@@ -75,7 +72,6 @@ public final class StorageSaveAndLoadTest {
     }
 
     @TestTemplate
-    @Timeout(1)
     void shouldSaveEmpty(final Storage storage) throws Exception {
         final Key key = new Key.From("shouldSaveEmpty");
         storage.save(key, new Content.From(Flowable.empty())).get();
@@ -87,8 +83,7 @@ public final class StorageSaveAndLoadTest {
     }
 
     @TestTemplate
-    @Timeout(1)
-    void shouldSaveWhenValueAlreadyExists(final Storage storage) throws Exception {
+    void shouldSaveWhenValueAlreadyExists(final Storage storage) {
         final BlockingStorage blocking = new BlockingStorage(storage);
         final byte[] original = "1".getBytes();
         final byte[] updated = "2".getBytes();
@@ -102,8 +97,7 @@ public final class StorageSaveAndLoadTest {
     }
 
     @TestTemplate
-    @Timeout(1)
-    void shouldFailToSaveErrorContent(final Storage storage) throws Exception {
+    void shouldFailToSaveErrorContent(final Storage storage) {
         Assertions.assertThrows(
             Exception.class,
             () -> storage.save(
@@ -114,8 +108,7 @@ public final class StorageSaveAndLoadTest {
     }
 
     @TestTemplate
-    @Timeout(1)
-    void shouldFailToLoadAbsentValue(final Storage storage) throws Exception {
+    void shouldFailToLoadAbsentValue(final Storage storage) {
         final BlockingStorage blocking = new BlockingStorage(storage);
         final Key key = new Key.From("shouldFailToLoadAbsentValue");
         Assertions.assertThrows(RuntimeException.class, () -> blocking.value(key));

--- a/src/test/java/com/artipie/asto/StorageSizeTest.java
+++ b/src/test/java/com/artipie/asto/StorageSizeTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public final class StorageSizeTest {
 
     @TestTemplate
-    void shouldGetSizeSave(final Storage storage) throws Exception {
+    void shouldGetSizeSave(final Storage storage) {
         final BlockingStorage blocking = new BlockingStorage(storage);
         final byte[] data = "0123456789".getBytes();
         final Key key = new Key.From("shouldGetSizeSave");

--- a/src/test/java/com/artipie/asto/s3/S3StorageTest.java
+++ b/src/test/java/com/artipie/asto/s3/S3StorageTest.java
@@ -136,7 +136,7 @@ class S3StorageTest {
     }
 
     @Test
-    void shouldExistForSavedObject(final AmazonS3 client) throws Exception {
+    void shouldExistForSavedObject(final AmazonS3 client) {
         final byte[] data = "content".getBytes();
         final String key = "some/existing/key";
         client.putObject(this.bucket, key, new ByteArrayInputStream(data), new ObjectMetadata());
@@ -149,7 +149,7 @@ class S3StorageTest {
     }
 
     @Test
-    void shouldListKeysInOrder(final AmazonS3 client) throws Exception {
+    void shouldListKeysInOrder(final AmazonS3 client) {
         final byte[] data = "some data!".getBytes();
         Arrays.asList(
             new Key.From("1"),
@@ -177,7 +177,7 @@ class S3StorageTest {
     }
 
     @Test
-    void shouldGetObjectWhenLoad(final AmazonS3 client) throws Exception {
+    void shouldGetObjectWhenLoad(final AmazonS3 client) {
         final byte[] data = "data".getBytes();
         final String key = "some/key";
         client.putObject(this.bucket, key, new ByteArrayInputStream(data), new ObjectMetadata());
@@ -231,7 +231,7 @@ class S3StorageTest {
     }
 
     @Test
-    void shouldDeleteObject(final AmazonS3 client) throws Exception {
+    void shouldDeleteObject(final AmazonS3 client) {
         final byte[] data = "to be deleted".getBytes();
         final String key = "to/be/deleted";
         client.putObject(this.bucket, key, new ByteArrayInputStream(data), new ObjectMetadata());

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -4,4 +4,4 @@ log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=com.jcabi.log.MulticolorLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=[%color{%p}] %t %c: %m%n
 
-log4j.logger.com.artipie.asto=DEBUG
+log4j.logger.com.yegor256.asto=DEBUG


### PR DESCRIPTION
Reverted changes made in #172 + bump Vert.x version to 3.9.1

Before:
```
$ git clone https://github.com/Sammers21/asto.git && cd asto && git checkout rio_repeat_100
$ mvn clean install -Dtest=FileStorageTest#saveAndLoadHugeFiles
...
Run #0. Time: 1s860ms
Run #1. Time: 1s697ms
Run #2. Time: 1s393ms
Run #3. Time: 1s351ms
Run #4. Time: 1s151ms
Run #5. Time: 1s262ms
Run #6. Time: 1s76ms
Run #7. Time: 1s72ms
Run #8. Time: 1s46ms
Run #9. Time: 1s36ms
Run #10. Time: 1s50ms
Run #11. Time: 1s42ms
Run #12. Time: 1s46ms
Run #13. Time: 1s65ms
Run #14. Time: 1s55ms
Run #15. Time: 1s47ms
Run #16. Time: 1s50ms
Run #17. Time: 1s49ms
Run #18. Time: 1s47ms
Run #19. Time: 1s58ms
...
```

After:
```
$ git clone https://github.com/Sammers21/asto.git && cd asto && git checkout back_to_vertx_repeat_100
$ mvn clean install -Dtest=FileStorageTest#saveAndLoadHugeFiles
...
Run #0. Time: 1s799ms
Run #1. Time: 0s601ms
Run #2. Time: 0s589ms
Run #3. Time: 0s582ms
Run #4. Time: 0s602ms
Run #5. Time: 0s590ms
Run #6. Time: 0s583ms
Run #7. Time: 0s598ms
Run #8. Time: 0s580ms
Run #9. Time: 0s586ms
Run #10. Time: 0s589ms
Run #11. Time: 0s588ms
Run #12. Time: 0s582ms
Run #13. Time: 0s584ms
Run #14. Time: 0s589ms
Run #15. Time: 0s577ms
Run #16. Time: 0s594ms
Run #17. Time: 0s590ms
Run #18. Time: 0s583ms
Run #19. Time: 0s582ms
...
```

From the benchmark above It is clear that the previous version outperforming the existing one by ~50%