### PR TITLE
Proper laziness in Rx components

### DIFF
--- a/src/main/java/com/artipie/asto/rx/RxStorageWrapper.java
+++ b/src/main/java/com/artipie/asto/rx/RxStorageWrapper.java
@@ -54,68 +54,50 @@ public final class RxStorageWrapper implements RxStorage {
         this.storage = storage;
     }
 
-    /**
-     * This file exists?
-     *
-     * @param key The key (file name)
-     * @return TRUE if exists, FALSE otherwise
-     */
+    @Override
     public Single<Boolean> exists(final Key key) {
-        return SingleInterop.fromFuture(this.storage.exists(key));
+        return Single.defer(() -> SingleInterop.fromFuture(this.storage.exists(key)));
     }
 
     @Override
     public Single<Collection<Key>> list(final Key prefix) {
-        return SingleInterop.fromFuture(this.storage.list(prefix));
+        return Single.defer(() -> SingleInterop.fromFuture(this.storage.list(prefix)));
     }
 
-    /**
-     * Saves the bytes to the specified key.
-     *
-     * @param key The key
-     * @param content Bytes to save
-     * @return Completion or error signal.
-     */
+    @Override
     public Completable save(final Key key, final Content content) {
-        return CompletableInterop.fromFuture(this.storage.save(key, content));
+        return Completable.defer(
+            () -> CompletableInterop.fromFuture(this.storage.save(key, content))
+        );
     }
 
     @Override
     public Completable move(final Key source, final Key destination) {
-        return CompletableInterop.fromFuture(this.storage.move(source, destination));
+        return Completable.defer(
+            () -> CompletableInterop.fromFuture(this.storage.move(source, destination))
+        );
     }
 
     @Override
     public Single<Long> size(final Key key) {
-        return SingleInterop.fromFuture(this.storage.size(key));
+        return Single.defer(() -> SingleInterop.fromFuture(this.storage.size(key)));
     }
 
-    /**
-     * Obtain bytes by key.
-     *
-     * @param key The key
-     * @return Bytes.
-     */
+    @Override
     public Single<Content> value(final Key key) {
-        return SingleInterop.fromFuture(this.storage.value(key));
+        return Single.defer(() -> SingleInterop.fromFuture(this.storage.value(key)));
     }
 
     @Override
     public Completable delete(final Key key) {
-        return CompletableInterop.fromFuture(this.storage.delete(key));
+        return Completable.defer(() -> CompletableInterop.fromFuture(this.storage.delete(key)));
     }
 
-    /**
-     * Start a transaction with specified keys. These specified keys are the scope of
-     * a transaction. You will be able to perform storage operations like
-     * {@link RxStorage#save(Key, Content)} or {@link RxStorage#value(Key)} only in
-     * the scope of a transaction.
-     *
-     * @param keys The keys regarding which transaction is atomic
-     * @return Transaction
-     */
+    @Override
     public Single<RxTransaction> transaction(final List<Key> keys) {
-        return SingleInterop.fromFuture(this.storage.transaction(keys))
-            .map(RxTransactionWrapper::new);
+        return Single.defer(
+            () -> SingleInterop.fromFuture(this.storage.transaction(keys))
+            .map(RxTransactionWrapper::new)
+        );
     }
 }

--- a/src/main/java/com/artipie/asto/rx/RxTransactionWrapper.java
+++ b/src/main/java/com/artipie/asto/rx/RxTransactionWrapper.java
@@ -55,59 +55,67 @@ public final class RxTransactionWrapper implements RxTransaction {
 
     @Override
     public Completable commit() {
-        return CompletableInterop.fromFuture(this.wrapped.commit());
+        return Completable.defer(() -> CompletableInterop.fromFuture(this.wrapped.commit()));
     }
 
     @Override
     public Completable rollback() {
-        return CompletableInterop.fromFuture(this.wrapped.rollback());
+        return Completable.defer(() -> CompletableInterop.fromFuture(this.wrapped.rollback()));
     }
 
     @Override
     public Single<Boolean> exists(final Key key) {
-        return SingleInterop.fromFuture(this.wrapped.exists(key));
+        return Single.defer(() -> SingleInterop.fromFuture(this.wrapped.exists(key)));
     }
 
     @Override
     public Single<Collection<Key>> list(final Key prefix) {
-        return SingleInterop.fromFuture(this.wrapped.list(prefix));
+        return Single.defer(() -> SingleInterop.fromFuture(this.wrapped.list(prefix)));
     }
 
     @Override
     public Completable save(final Key key, final Content content) {
-        return CompletableInterop.fromFuture(
-            this.wrapped.save(
-                key,
-                content
+        return Completable.defer(
+            () -> CompletableInterop.fromFuture(
+                this.wrapped.save(
+                    key,
+                    content
+                )
             )
         );
     }
 
     @Override
     public Completable move(final Key source, final Key destination) {
-        return CompletableInterop.fromFuture(
-            this.wrapped.move(source, destination)
+        return Completable.defer(
+            () -> CompletableInterop.fromFuture(
+                this.wrapped.move(source, destination)
+            )
         );
     }
 
     @Override
     public Single<Long> size(final Key key) {
-        return SingleInterop.fromFuture(this.wrapped.size(key));
+        return Single.defer(() -> SingleInterop.fromFuture(this.wrapped.size(key)));
     }
 
     @Override
     public Single<Content> value(final Key key) {
-        return SingleInterop.fromFuture(this.wrapped.value(key));
+        return Single.defer(() -> SingleInterop.fromFuture(this.wrapped.value(key)));
     }
 
     @Override
     public Completable delete(final Key key) {
-        return CompletableInterop.fromFuture(this.wrapped.delete(key));
+        return Completable.defer(
+            () -> Completable.defer(() -> CompletableInterop.fromFuture(this.wrapped.delete(key)))
+        );
     }
 
     @Override
     public Single<RxTransaction> transaction(final List<Key> keys) {
-        return SingleInterop.fromFuture(this.wrapped.transaction(keys))
-            .map(RxTransactionWrapper::new);
+        return Single.defer(
+            () -> SingleInterop.fromFuture(this.wrapped.transaction(keys))
+                .map(RxTransactionWrapper::new)
+        );
     }
 }


### PR DESCRIPTION
All the methods returning Rx primitives made properly lazy: using Rx `defer` to start execution only after `subscribe` call.

Closes #189 