### PR TITLE
#203 - Atomic save in FileStorage

### DIFF
--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -162,7 +162,8 @@ public final class FileStorage implements Storage {
                 );
                 tmp.getParent().toFile().mkdirs();
                 return tmp;
-            }
+            },
+            this.exec
         ).thenCompose(
             tmp -> new File(tmp).write(
                 new OneTimePublisher<>(content),
@@ -172,7 +173,7 @@ public final class FileStorage implements Storage {
                 StandardOpenOption.TRUNCATE_EXISTING
             ).thenCompose(
                 nothing -> this.move(tmp, this.path(key))
-            ).handle(
+            ).handleAsync(
                 (nothing, throwable) -> {
                     tmp.toFile().delete();
                     final CompletableFuture<Void> result = new CompletableFuture<>();
@@ -182,7 +183,8 @@ public final class FileStorage implements Storage {
                         result.completeExceptionally(throwable);
                     }
                     return result;
-                }
+                },
+                this.exec
             ).thenCompose(Function.identity())
         );
     }
@@ -239,7 +241,7 @@ public final class FileStorage implements Storage {
      * @param dest Destination path.
      * @return Completion of moving file.
      */
-    public CompletableFuture<Void> move(final Path source, final Path dest) {
+    private CompletableFuture<Void> move(final Path source, final Path dest) {
         return CompletableFuture.supplyAsync(
             () -> {
                 dest.getParent().toFile().mkdirs();

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -89,6 +90,18 @@ final class FileStorageTest {
         MatcherAssert.assertThat(
             blocking.value(key),
             new IsEqual<>(updated)
+        );
+    }
+
+    @Test
+    void saveBadContentDoesNotLeaveTrace() {
+        this.storage.save(
+            new Key.From("a/b/c/"),
+            new Content.From(Flowable.error(new IllegalStateException()))
+        ).exceptionally(ignored -> null).join();
+        MatcherAssert.assertThat(
+            this.storage.list(Key.ROOT).join(),
+            new IsEmptyCollection<>()
         );
     }
 

--- a/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
+++ b/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
@@ -122,4 +122,23 @@ public final class StorageSaveAndLoadTest {
         final Key key = new Key.From("shouldFailToLoadAbsentValue");
         Assertions.assertThrows(RuntimeException.class, () -> blocking.value(key));
     }
+
+    @TestTemplate
+    @Timeout(1)
+    void shouldNotSavePartial(final Storage storage) {
+        final Key key = new Key.From("shouldNotSavePartial");
+        storage.save(
+            key,
+            new Content.From(
+                Flowable.concat(
+                    Flowable.just(ByteBuffer.wrap(new byte[] {1})),
+                    Flowable.error(new IllegalStateException())
+                )
+            )
+        ).exceptionally(ignored -> null).join();
+        MatcherAssert.assertThat(
+            storage.exists(key).join(),
+            Matchers.equalTo(false)
+        );
+    }
 }


### PR DESCRIPTION
Closes #203 
Atomic `FileStorage.save` writes data to temporary file first, then moves it to end destination