### PR TITLE
Test that value returned content is always consumable only once

### DIFF
--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -225,7 +225,9 @@ public final class FileStorage implements Storage {
     @Override
     public CompletableFuture<Content> value(final Key key) {
         return this.size(key).thenApply(
-            size -> new Content.From(new File(this.path(key)).content(this.exec))
+            size -> new Content.OneTime(
+                new Content.From(new File(this.path(key)).content(this.exec))
+            )
         );
     }
 

--- a/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
+++ b/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
@@ -117,6 +117,24 @@ public final class StorageSaveAndLoadTest {
 
     @TestTemplate
     @Timeout(1)
+    void shouldFailOnSecondConsumeAttempt(final Storage storage) {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> {
+                final Key.From key = new Key.From("key");
+                storage.save(
+                    key,
+                    new Content.OneTime(new Content.From("val".getBytes()))
+                ).join();
+                final Content value = storage.value(key).join();
+                Flowable.fromPublisher(value).toList().blockingGet();
+                Flowable.fromPublisher(value).toList().blockingGet();
+            }
+        );
+    }
+
+    @TestTemplate
+    @Timeout(1)
     void shouldFailToLoadAbsentValue(final Storage storage) throws Exception {
         final BlockingStorage blocking = new BlockingStorage(storage);
         final Key key = new Key.From("shouldFailToLoadAbsentValue");

--- a/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
+++ b/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
@@ -118,18 +118,16 @@ public final class StorageSaveAndLoadTest {
     @TestTemplate
     @Timeout(1)
     void shouldFailOnSecondConsumeAttempt(final Storage storage) {
+        final Key.From key = new Key.From("key");
+        storage.save(
+            key,
+            new Content.OneTime(new Content.From("val".getBytes()))
+        ).join();
+        final Content value = storage.value(key).join();
+        Flowable.fromPublisher(value).toList().blockingGet();
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> {
-                final Key.From key = new Key.From("key");
-                storage.save(
-                    key,
-                    new Content.OneTime(new Content.From("val".getBytes()))
-                ).join();
-                final Content value = storage.value(key).join();
-                Flowable.fromPublisher(value).toList().blockingGet();
-                Flowable.fromPublisher(value).toList().blockingGet();
-            }
+            () -> Flowable.fromPublisher(value).toList().blockingGet()
         );
     }
 


### PR DESCRIPTION
Closes #204 

* A test which ensures that the returned content is always consumable only once has been created
* FileStorage was fixed so the test passes