### PR TITLE
Extended storage javadoc

### DIFF
--- a/src/main/java/com/artipie/asto/Storage.java
+++ b/src/main/java/com/artipie/asto/Storage.java
@@ -50,7 +50,8 @@ public interface Storage {
 
     /**
      * Return the list of keys that start with this prefix, for
-     * example "foo/bar/".
+     * example "foo/bar/". Resulting list is sorted by string
+     * representation of the keys.
      *
      * @param prefix The prefix.
      * @return Collection of relative keys.


### PR DESCRIPTION
Extended storage javadoc to say that `list` should be sorted.