### PR TITLE
Initial storage cache implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@ SOFTWARE.
       <artifactId>commons-codec</artifactId>
       <version>1.14</version>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.1</version>
+    </dependency>
     <!-- TestNG compatibility layer with Junit5 -->
     <dependency>
       <groupId>com.github.testng-team</groupId>

--- a/src/main/java/com/artipie/asto/cache/Cache.java
+++ b/src/main/java/com/artipie/asto/cache/Cache.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.asto.cache;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+/**
+ * Generic reactive cache which returns cached content by key of exist or loads from remote and
+ * cache if doesn't exit.
+ *
+ * @since 0.24
+ */
+public interface Cache {
+
+    /**
+     * No cache, just load remote resource.
+     */
+    Cache NOP = (key, remote, ctl) -> remote.get();
+
+    /**
+     * Try to load content from cache or fallback to remote publisher if cached key doesn't exist.
+     * When loading remote item, the cache may save its content to the cache storage.
+     * @param key Cached item key
+     * @param remote Remote source
+     * @param control Cache control
+     * @return Content for key
+     */
+    CompletionStage<? extends Content> load(
+        Key key, Supplier<? extends CompletionStage<? extends Content>> remote,
+        CacheControl control
+    );
+}

--- a/src/main/java/com/artipie/asto/cache/CacheControl.java
+++ b/src/main/java/com/artipie/asto/cache/CacheControl.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.asto.cache;
+
+import com.artipie.asto.Key;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Cache control.
+ * @since 0.24
+ */
+public interface CacheControl {
+
+    /**
+     * Standard cache controls.
+     * @since 0.24
+     */
+    enum Standard implements CacheControl {
+        /**
+         * Don't use cache, always invalidate.
+         */
+        NO_CACHE(item -> CompletableFuture.completedFuture(false)),
+        /**
+         * Always use cache, don't invalidate.
+         */
+        ALWAYS(item -> CompletableFuture.completedFuture(true));
+
+        /**
+         * Origin cache control.
+         */
+        private final CacheControl origin;
+
+        /**
+         * Ctor.
+         * @param origin Cache control
+         */
+        Standard(final CacheControl origin) {
+            this.origin = origin;
+        }
+
+        @Override
+        public CompletionStage<Boolean> validate(final Key item) {
+            return this.origin.validate(item);
+        }
+    }
+
+    /**
+     * Validate cached item.
+     * @param item Cached item
+     * @return True if valid
+     */
+    CompletionStage<Boolean> validate(Key item);
+}

--- a/src/main/java/com/artipie/asto/cache/CacheControl.java
+++ b/src/main/java/com/artipie/asto/cache/CacheControl.java
@@ -70,7 +70,7 @@ public interface CacheControl {
      * Validate cached item: checks if cached value can be used or needs to be updated by fresh
      * value.
      * @param item Cached item
-     * @return True if cached item can be user, false if needs to be updated
+     * @return True if cached item can be used, false if needs to be updated
      */
     CompletionStage<Boolean> validate(Key item);
 }

--- a/src/main/java/com/artipie/asto/cache/CacheControl.java
+++ b/src/main/java/com/artipie/asto/cache/CacheControl.java
@@ -67,9 +67,10 @@ public interface CacheControl {
     }
 
     /**
-     * Validate cached item.
+     * Validate cached item: checks if cached value can be used or needs to be updated by fresh
+     * value.
      * @param item Cached item
-     * @return True if valid
+     * @return True if cached item can be user, false if needs to be updated
      */
     CompletionStage<Boolean> validate(Key item);
 }

--- a/src/main/java/com/artipie/asto/cache/StorageCache.java
+++ b/src/main/java/com/artipie/asto/cache/StorageCache.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.asto.cache;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.rx.RxStorageWrapper;
+import hu.akarnokd.rxjava2.interop.SingleInterop;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+/**
+ * Storage cache implementation.
+ * @since 0.24
+ */
+public final class StorageCache implements Cache {
+
+    /**
+     * Back-end storage.
+     */
+    private final Storage storage;
+
+    /**
+     * New storage cache.
+     * @param storage Back-end storage for cache
+     */
+    public StorageCache(final Storage storage) {
+        this.storage = storage;
+    }
+
+    @Override
+    public CompletionStage<? extends Content> load(final Key key,
+        final Supplier<? extends CompletionStage<? extends Content>> remote,
+        final CacheControl control) {
+        final RxStorageWrapper rxsto = new RxStorageWrapper(this.storage);
+        return rxsto.exists(key)
+            .filter(exists -> exists)
+            .flatMapSingleElement(
+                exists -> SingleInterop.fromFuture(control.validate(key))
+                    .map(valid -> exists && valid)
+            )
+            .filter(valid -> valid)
+            .flatMapSingleElement(ignore -> rxsto.value(key))
+            .switchIfEmpty(
+                SingleInterop.fromFuture(remote.get()).flatMapCompletable(
+                    content -> rxsto.save(
+                        key, new Content.From(content.size(), content)
+                    )
+                ).andThen(rxsto.value(key))
+            ).to(SingleInterop.get());
+    }
+}

--- a/src/main/java/com/artipie/asto/cache/package-info.java
+++ b/src/main/java/com/artipie/asto/cache/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Caching objects.
+ *
+ * @since 0.24
+ */
+package com.artipie.asto.cache;

--- a/src/main/java/com/artipie/asto/test/ContentIs.java
+++ b/src/main/java/com/artipie/asto/test/ContentIs.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.asto.test;
+
+import com.artipie.asto.Concatenation;
+import com.artipie.asto.Content;
+import com.artipie.asto.Remaining;
+import java.nio.charset.Charset;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Matcher for {@link Content}.
+ * @since 0.24
+ */
+public final class ContentIs extends TypeSafeMatcher<Content> {
+
+    /**
+     * Byte array matcher.
+     */
+    private final Matcher<byte[]> matcher;
+
+    /**
+     * Content is a string with encoding.
+     * @param expected String
+     * @param enc Encoding charset
+     */
+    public ContentIs(final String expected, final Charset enc) {
+        this(expected.getBytes(enc));
+    }
+
+    /**
+     * Content is a byte array.
+     * @param expected Byte array
+     */
+    public ContentIs(final byte[] expected) {
+        this(Matchers.equalTo(expected));
+    }
+
+    /**
+     * Content matches for byte array matcher.
+     * @param matcher Byte array matcher
+     */
+    public ContentIs(final Matcher<byte[]> matcher) {
+        this.matcher = matcher;
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText("has bytes ").appendValue(this.matcher);
+    }
+
+    @Override
+    public boolean matchesSafely(final Content item) {
+        final byte[] actual = new Concatenation(item).single()
+            .map(buf -> new Remaining(buf).bytes()).blockingGet();
+        return this.matcher.matches(actual);
+    }
+}

--- a/src/test/java/com/artipie/asto/cache/StorageCacheTest.java
+++ b/src/test/java/com/artipie/asto/cache/StorageCacheTest.java
@@ -1,0 +1,177 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.asto.cache;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.asto.test.ContentIs;
+import com.jcabi.log.Logger;
+import hu.akarnokd.rxjava2.interop.CompletableInterop;
+import hu.akarnokd.rxjava2.interop.SingleInterop;
+import io.reactivex.Flowable;
+import io.reactivex.Observable;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link StorageCache}.
+ *
+ * @since 0.24
+ * @checkstyle MagicNumberCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+final class StorageCacheTest {
+
+    @Test
+    void loadsFromCache() throws Exception {
+        final Storage storage = new InMemoryStorage();
+        final Key key = new Key.From("key1");
+        final byte[] data = "hello1".getBytes();
+        new BlockingStorage(storage).save(key, data);
+        MatcherAssert.assertThat(
+            new StorageCache(storage).load(
+                key,
+                () -> CompletableFuture.supplyAsync(
+                    () -> {
+                        throw new IllegalStateException("Failing remote 1");
+                    }
+                ),
+                CacheControl.Standard.ALWAYS
+            ).toCompletableFuture().get(),
+            new ContentIs(data)
+        );
+    }
+
+    @Test
+    void savesToCacheFromRemote() throws Exception {
+        final Storage storage = new InMemoryStorage();
+        final Key key = new Key.From("key2");
+        final byte[] data = "hello2".getBytes();
+        final StorageCache cache = new StorageCache(storage);
+        final Content load = cache.load(
+            key,
+            () -> CompletableFuture.supplyAsync(() -> new Content.From(data)),
+            CacheControl.Standard.ALWAYS
+        ).toCompletableFuture().get();
+        MatcherAssert.assertThat(
+            "Cache returned broken remote content",
+            load, new ContentIs(data)
+        );
+        MatcherAssert.assertThat(
+            "Cache didn't save remote content locally",
+            cache.load(
+                key,
+                () -> CompletableFuture.supplyAsync(
+                    () -> {
+                        throw new IllegalStateException("Failing remote 1");
+                    }
+                ),
+                CacheControl.Standard.ALWAYS
+            ).toCompletableFuture().get(),
+            new ContentIs(data)
+        );
+    }
+
+    @Test
+    void dontCacheFailedRemote() throws Exception {
+        final Storage storage = new InMemoryStorage();
+        final Key key = new Key.From("key3");
+        final AtomicInteger cnt = new AtomicInteger();
+        new StorageCache(storage).load(
+            key,
+            () -> CompletableFuture.supplyAsync(
+                () -> new Content.From(
+                    Flowable.generate(
+                        emitter -> {
+                            if (cnt.incrementAndGet() < 3) {
+                                emitter.onNext(ByteBuffer.allocate(4));
+                            } else {
+                                emitter.onError(new Exception("Error!"));
+                            }
+                        }
+                    )
+                )
+            ),
+            CacheControl.Standard.ALWAYS
+        ).exceptionally(
+            err -> {
+                Logger.info(this, "Handled error: %s", err.getMessage());
+                return null;
+            }
+        ).toCompletableFuture().get();
+        MatcherAssert.assertThat(
+            new BlockingStorage(storage).exists(key), Matchers.is(false)
+        );
+    }
+
+    @Test
+    void processMultipleRequestsSimultaneously() throws Exception {
+        final Storage storage = new InMemoryStorage();
+        final StorageCache cache = new StorageCache(storage);
+        final Key key = new Key.From("key4");
+        final int count = 100;
+        final CountDownLatch latch = new CountDownLatch(10);
+        final byte[] data = "data".getBytes();
+        final Supplier<CompletionStage<? extends Content>> remote =
+            () -> CompletableFuture.supplyAsync(
+                // @checkstyle ReturnCountCheck (10 lines)
+                () -> {
+                    latch.countDown();
+                    try {
+                        latch.await();
+                    } catch (final InterruptedException ignore) {
+                        Thread.currentThread().interrupt();
+                        return null;
+                    }
+                    return new Content.From(Flowable.just(ByteBuffer.wrap(data)));
+                }
+            );
+        Observable.range(0, count).flatMapCompletable(
+            num -> SingleInterop.fromFuture(cache.load(key, remote, CacheControl.Standard.ALWAYS))
+                .flatMapCompletable(
+                    pub -> CompletableInterop.fromFuture(
+                        storage.save(new Key.From("out", num.toString()), pub)
+                    )
+                )
+        ).blockingAwait();
+        for (int num = 0; num < count; ++num) {
+            MatcherAssert.assertThat(
+                new BlockingStorage(storage).value(new Key.From("out", String.valueOf(num))),
+                Matchers.equalTo(data)
+            );
+        }
+    }
+}

--- a/src/test/java/com/artipie/asto/cache/package-info.java
+++ b/src/test/java/com/artipie/asto/cache/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Tests for cache.
+ *
+ * @since 0.24
+ */
+package com.artipie.asto.cache;
+


### PR DESCRIPTION
#225 - initial storage cache implementation:
 - created primitive `StorageCache` implementation to improve it later (reads from remote to storage and returns storage after that)
 - created basic interfaces `Cache` and `CacheControl`
 - unit tests for `StorageCache` 