### PR TITLE
#231 - Using expiration time when acquiring StorageLock

### DIFF
--- a/src/main/java/com/artipie/asto/lock/storage/Proposals.java
+++ b/src/main/java/com/artipie/asto/lock/storage/Proposals.java
@@ -26,6 +26,7 @@ package com.artipie.asto.lock.storage;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
+import com.artipie.asto.ext.PublisherAs;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Optional;
@@ -84,23 +85,44 @@ final class Proposals {
      * @return Completion of proposals check operation.
      */
     public CompletionStage<Void> checkSingle(final String uuid) {
-        final Key expected = this.proposalKey(uuid);
+        final Key own = this.proposalKey(uuid);
         return this.storage.list(new RootKey(this.target)).thenCompose(
-            proposals -> {
-                if (proposals.size() != 1 || !proposals.contains(expected)) {
-                    throw new IllegalStateException(
-                        String.format(
-                            "Failed to acquire lock. Own: `%s` Found: %s",
-                            expected,
-                            proposals.stream()
-                                .map(Key::toString)
-                                .map(str -> String.format("`%s`", str))
-                                .collect(Collectors.joining(", "))
-                        )
-                    );
-                }
-                return CompletableFuture.allOf();
-            }
+            proposals -> CompletableFuture.allOf(
+                proposals.stream()
+                    .filter(key -> !key.equals(own))
+                    .map(
+                        proposal -> this.storage.value(proposal)
+                            .thenApply(PublisherAs::new)
+                            .thenCompose(PublisherAs::asciiString)
+                            .thenCompose(
+                                expiration -> {
+                                    if (isNotExpired(expiration)) {
+                                        throw new IllegalStateException(
+                                            String.join(
+                                                "\n",
+                                                "Failed to acquire lock.",
+                                                String.format("Own: `%s`", own),
+                                                String.format(
+                                                    "Others: %s",
+                                                    proposals.stream()
+                                                        .map(Key::toString)
+                                                        .map(str -> String.format("`%s`", str))
+                                                        .collect(Collectors.joining(", "))
+                                                ),
+                                                String.format(
+                                                    "Not expired: `%s` `%s`",
+                                                    proposal,
+                                                    expiration
+                                                )
+                                            )
+                                        );
+                                    }
+                                    return CompletableFuture.allOf();
+                                }
+                            )
+                    )
+                    .toArray(CompletableFuture[]::new)
+            )
         );
     }
 
@@ -122,6 +144,17 @@ final class Proposals {
      */
     private Key proposalKey(final String uuid) {
         return new Key.From(new RootKey(this.target), uuid);
+    }
+
+    /**
+     * Checks that instant in string format is not expired, e.g. is after current time.
+     * Empty string considered to never expire.
+     *
+     * @param instant Instant in string format.
+     * @return True if instant is not expired, false - otherwise.
+     */
+    private static boolean isNotExpired(final String instant) {
+        return instant.isEmpty() || Instant.parse(instant).isAfter(Instant.now());
     }
 
     /**

--- a/src/main/java/com/artipie/asto/lock/storage/Proposals.java
+++ b/src/main/java/com/artipie/asto/lock/storage/Proposals.java
@@ -85,6 +85,7 @@ final class Proposals {
      * @return Completion of proposals check operation.
      */
     public CompletionStage<Void> checkSingle(final String uuid) {
+        final Instant now = Instant.now();
         final Key own = this.proposalKey(uuid);
         return this.storage.list(new RootKey(this.target)).thenCompose(
             proposals -> CompletableFuture.allOf(
@@ -96,7 +97,7 @@ final class Proposals {
                             .thenCompose(PublisherAs::asciiString)
                             .thenCompose(
                                 expiration -> {
-                                    if (isNotExpired(expiration)) {
+                                    if (isNotExpired(expiration, now)) {
                                         throw new IllegalStateException(
                                             String.join(
                                                 "\n",
@@ -151,10 +152,11 @@ final class Proposals {
      * Empty string considered to never expire.
      *
      * @param instant Instant in string format.
+     * @param now Current time.
      * @return True if instant is not expired, false - otherwise.
      */
-    private static boolean isNotExpired(final String instant) {
-        return instant.isEmpty() || Instant.parse(instant).isAfter(Instant.now());
+    private static boolean isNotExpired(final String instant, final Instant now) {
+        return instant.isEmpty() || Instant.parse(instant).isAfter(now);
     }
 
     /**


### PR DESCRIPTION
Closes #231 
Using expiration time when acquiring `StorageLock`. Acquiring fails only if not expired proposals exists.