### PR TITLE
#237 - Changed Storage.transaction to accept only one Key

### DIFF
--- a/src/main/java/com/artipie/asto/LoggingStorage.java
+++ b/src/main/java/com/artipie/asto/LoggingStorage.java
@@ -25,10 +25,8 @@ package com.artipie.asto;
 
 import com.jcabi.log.Logger;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 /**
  * Storage that logs performed operations.
@@ -138,13 +136,10 @@ public final class LoggingStorage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Transaction> transaction(final List<Key> keys) {
-        return this.storage.transaction(keys).thenApply(
+    public CompletableFuture<Transaction> transaction(final Key key) {
+        return this.storage.transaction(key).thenApply(
             result -> {
-                this.log(
-                    "Transaction '%s'",
-                    keys.stream().map(Key::string).collect(Collectors.joining(", "))
-                );
+                this.log("Transaction '%s'", key);
                 return result;
             }
         );

--- a/src/main/java/com/artipie/asto/Storage.java
+++ b/src/main/java/com/artipie/asto/Storage.java
@@ -25,7 +25,6 @@ package com.artipie.asto;
 
 import com.artipie.asto.fs.FileStorage;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -100,15 +99,15 @@ public interface Storage {
     CompletableFuture<Void> delete(Key key);
 
     /**
-     * Start a transaction with specified keys. These specified keys are the scope of
-     * a transaction. You will be able to perform storage operations like
+     * Start a transaction with specified key. This specified key is the scope of
+     * transaction. You will be able to perform storage operations like
      * {@link Storage#save(Key, Content)} or {@link Storage#value(Key)} only in
-     * the scope of a transaction.
+     * the scope of transaction.
      *
-     * @param keys The keys regarding which transaction is atomic
+     * @param key Key which is scope of transaction
      * @return Transaction
      */
-    CompletableFuture<Transaction> transaction(List<Key> keys);
+    CompletableFuture<Transaction> transaction(Key key);
 
     /**
      * Forwarding decorator for {@link Storage}.
@@ -167,8 +166,8 @@ public interface Storage {
         }
 
         @Override
-        public final CompletableFuture<Transaction> transaction(final List<Key> keys) {
-            return this.delegate.transaction(keys);
+        public final CompletableFuture<Transaction> transaction(final Key key) {
+            return this.delegate.transaction(key);
         }
     }
 }

--- a/src/main/java/com/artipie/asto/SubStorage.java
+++ b/src/main/java/com/artipie/asto/SubStorage.java
@@ -24,7 +24,6 @@
 package com.artipie.asto;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -106,7 +105,7 @@ public final class SubStorage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Transaction> transaction(final List<Key> keys) {
+    public CompletableFuture<Transaction> transaction(final Key key) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -40,7 +40,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -232,7 +231,7 @@ public final class FileStorage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Transaction> transaction(final List<Key> keys) {
+    public CompletableFuture<Transaction> transaction(final Key key) {
         return CompletableFuture.completedFuture(new FileSystemTransaction(this));
     }
 

--- a/src/main/java/com/artipie/asto/fs/FileSystemTransaction.java
+++ b/src/main/java/com/artipie/asto/fs/FileSystemTransaction.java
@@ -28,7 +28,6 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.Transaction;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -89,9 +88,7 @@ public final class FileSystemTransaction implements Transaction {
     }
 
     @Override
-    public CompletableFuture<Transaction> transaction(
-        // @checkstyle HiddenFieldCheck (1 line)
-        final List<Key> keys) {
+    public CompletableFuture<Transaction> transaction(final Key key) {
         return CompletableFuture.completedFuture(this);
     }
 

--- a/src/main/java/com/artipie/asto/memory/InMemoryStorage.java
+++ b/src/main/java/com/artipie/asto/memory/InMemoryStorage.java
@@ -33,7 +33,6 @@ import com.artipie.asto.Transaction;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
@@ -174,7 +173,7 @@ public final class InMemoryStorage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Transaction> transaction(final List<Key> keys) {
+    public CompletableFuture<Transaction> transaction(final Key key) {
         return CompletableFuture.completedFuture(new InMemoryTransaction(this));
     }
 }

--- a/src/main/java/com/artipie/asto/memory/InMemoryTransaction.java
+++ b/src/main/java/com/artipie/asto/memory/InMemoryTransaction.java
@@ -28,7 +28,6 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.Transaction;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -88,7 +87,7 @@ public final class InMemoryTransaction implements Transaction {
     }
 
     @Override
-    public CompletableFuture<Transaction> transaction(final List<Key> keys) {
+    public CompletableFuture<Transaction> transaction(final Key key) {
         return CompletableFuture.completedFuture(this);
     }
 

--- a/src/main/java/com/artipie/asto/rx/RxStorage.java
+++ b/src/main/java/com/artipie/asto/rx/RxStorage.java
@@ -28,7 +28,6 @@ import com.artipie.asto.Key;
 import io.reactivex.Completable;
 import io.reactivex.Single;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * A reactive version of {@link com.artipie.asto.Storage}.
@@ -97,10 +96,10 @@ public interface RxStorage {
     Completable delete(Key key);
 
     /**
-     * Start a transaction with specified keys.
+     * Start a transaction with specified key.
      *
-     * @param keys The keys regarding which transaction is atomic
+     * @param key Key which is scope of transaction
      * @return Transaction
      */
-    Single<RxTransaction> transaction(List<Key> keys);
+    Single<RxTransaction> transaction(Key key);
 }

--- a/src/main/java/com/artipie/asto/rx/RxStorageWrapper.java
+++ b/src/main/java/com/artipie/asto/rx/RxStorageWrapper.java
@@ -31,7 +31,6 @@ import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Completable;
 import io.reactivex.Single;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Reactive wrapper over {@code Storage}.
@@ -94,9 +93,9 @@ public final class RxStorageWrapper implements RxStorage {
     }
 
     @Override
-    public Single<RxTransaction> transaction(final List<Key> keys) {
+    public Single<RxTransaction> transaction(final Key key) {
         return Single.defer(
-            () -> SingleInterop.fromFuture(this.storage.transaction(keys))
+            () -> SingleInterop.fromFuture(this.storage.transaction(key))
             .map(RxTransactionWrapper::new)
         );
     }

--- a/src/main/java/com/artipie/asto/rx/RxTransactionWrapper.java
+++ b/src/main/java/com/artipie/asto/rx/RxTransactionWrapper.java
@@ -31,7 +31,6 @@ import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Completable;
 import io.reactivex.Single;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * A reactive wrapper of {@link RxTransaction}.
@@ -112,9 +111,9 @@ public final class RxTransactionWrapper implements RxTransaction {
     }
 
     @Override
-    public Single<RxTransaction> transaction(final List<Key> keys) {
+    public Single<RxTransaction> transaction(final Key key) {
         return Single.defer(
-            () -> SingleInterop.fromFuture(this.wrapped.transaction(keys))
+            () -> SingleInterop.fromFuture(this.wrapped.transaction(key))
                 .map(RxTransactionWrapper::new)
         );
     }

--- a/src/main/java/com/artipie/asto/s3/S3Storage.java
+++ b/src/main/java/com/artipie/asto/s3/S3Storage.java
@@ -36,7 +36,6 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -259,7 +258,7 @@ public final class S3Storage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Transaction> transaction(final List<Key> keys) {
+    public CompletableFuture<Transaction> transaction(final Key key) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/com/artipie/asto/StorageExtension.java
+++ b/src/test/java/com/artipie/asto/StorageExtension.java
@@ -90,7 +90,7 @@ final class StorageExtension
         try {
             storages = Arrays.asList(
                 new InMemoryStorage(),
-                new InMemoryStorage().transaction(Collections.emptyList()).get(),
+                new InMemoryStorage().transaction(Key.ROOT).get(),
                 this.s3Storage(),
                 new SubStorage(new Key.From("prefix"), new InMemoryStorage()),
                 new FileStorage(Files.createTempDirectory("junit"))


### PR DESCRIPTION
Part of #237 
Changed `Storage.transaction` to accept only one `Key`.