### PR TITLE
#237 - Proper handling of errors in Storage.exclusively implementations

### DIFF
--- a/src/main/java/com/artipie/asto/UnderLockOperation.java
+++ b/src/main/java/com/artipie/asto/UnderLockOperation.java
@@ -81,7 +81,7 @@ public final class UnderLockOperation<T> {
                 }
                 return result.handle(
                     (value, throwable) -> this.lock.release().thenCompose(
-                        nthng -> {
+                        released -> {
                             final CompletableFuture<T> future = new CompletableFuture<>();
                             if (throwable == null) {
                                 future.complete(value);


### PR DESCRIPTION
Closes #237
Proper handling of errors in `Storage.exclusively` implementations