### PR TITLE
#260 - Throwing ValueNotFoundException when value absent in storage

### DIFF
--- a/src/main/java/com/artipie/asto/ValueNotFoundException.java
+++ b/src/main/java/com/artipie/asto/ValueNotFoundException.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.asto;
+
+/**
+ * Exception indicating that value cannot be found in storage.
+ *
+ * @since 0.28
+ */
+@SuppressWarnings("serial")
+public class ValueNotFoundException extends RuntimeException {
+
+    /**
+     * Ctor.
+     *
+     * @param key Key that was not found.
+     */
+    public ValueNotFoundException(final Key key) {
+        super(message(key));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param key Key that was not found.
+     * @param cause Original cause for exception.
+     */
+    public ValueNotFoundException(final Key key, final Throwable cause) {
+        super(message(key), cause);
+    }
+
+    /**
+     * Build exception message for given key.
+     *
+     * @param key Key that was not found.
+     * @return Message string.
+     */
+    private static String message(final Key key) {
+        return String.format("No value for key: %s", key.string());
+    }
+}

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -28,12 +28,14 @@ import com.artipie.asto.Key;
 import com.artipie.asto.OneTimePublisher;
 import com.artipie.asto.Storage;
 import com.artipie.asto.UnderLockOperation;
+import com.artipie.asto.ValueNotFoundException;
 import com.artipie.asto.lock.storage.StorageLock;
 import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -216,6 +218,8 @@ public final class FileStorage implements Storage {
             () -> {
                 try {
                     return Files.size(this.path(key));
+                } catch (final NoSuchFileException nofile) {
+                    throw new ValueNotFoundException(key, nofile);
                 } catch (final IOException iex) {
                     throw new UncheckedIOException(iex);
                 }

--- a/src/main/java/com/artipie/asto/memory/InMemoryStorage.java
+++ b/src/main/java/com/artipie/asto/memory/InMemoryStorage.java
@@ -30,6 +30,7 @@ import com.artipie.asto.OneTimePublisher;
 import com.artipie.asto.Remaining;
 import com.artipie.asto.Storage;
 import com.artipie.asto.UnderLockOperation;
+import com.artipie.asto.ValueNotFoundException;
 import com.artipie.asto.lock.storage.StorageLock;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import java.util.Collection;
@@ -44,6 +45,7 @@ import java.util.function.Function;
  * Simple implementation of Storage that holds all data in memory.
  *
  * @since 0.14
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class InMemoryStorage implements Storage {
@@ -131,9 +133,7 @@ public final class InMemoryStorage implements Storage {
                 synchronized (this.data) {
                     final byte[] content = this.data.get(key.string());
                     if (content == null) {
-                        throw new IllegalArgumentException(
-                            String.format("No value for key: %s", key.string())
-                        );
+                        throw new ValueNotFoundException(key);
                     }
                     return (long) content.length;
                 }
@@ -148,9 +148,7 @@ public final class InMemoryStorage implements Storage {
                 synchronized (this.data) {
                     final byte[] content = this.data.get(key.string());
                     if (content == null) {
-                        throw new IllegalArgumentException(
-                            String.format("No value for key: %s", key.string())
-                        );
+                        throw new ValueNotFoundException(key);
                     }
                     return new Content.OneTime(new Content.From(content));
                 }

--- a/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
+++ b/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
@@ -26,9 +26,12 @@ package com.artipie.asto;
 import com.artipie.asto.blocking.BlockingStorage;
 import io.reactivex.Flowable;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.Timeout;
@@ -134,10 +137,18 @@ public final class StorageSaveAndLoadTest {
 
     @TestTemplate
     @Timeout(1)
-    void shouldFailToLoadAbsentValue(final Storage storage) throws Exception {
-        final BlockingStorage blocking = new BlockingStorage(storage);
-        final Key key = new Key.From("shouldFailToLoadAbsentValue");
-        Assertions.assertThrows(RuntimeException.class, () -> blocking.value(key));
+    void shouldFailToLoadAbsentValue(final Storage storage) {
+        final CompletableFuture<Content> value = storage.value(
+            new Key.From("shouldFailToLoadAbsentValue")
+        );
+        final Exception exception = Assertions.assertThrows(
+            CompletionException.class,
+            value::join
+        );
+        MatcherAssert.assertThat(
+            exception.getCause(),
+            new IsInstanceOf(ValueNotFoundException.class)
+        );
     }
 
     @TestTemplate

--- a/src/test/java/com/artipie/asto/StorageSizeTest.java
+++ b/src/test/java/com/artipie/asto/StorageSizeTest.java
@@ -24,8 +24,11 @@
 package com.artipie.asto;
 
 import com.artipie.asto.blocking.BlockingStorage;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,8 +52,16 @@ public final class StorageSizeTest {
 
     @TestTemplate
     void shouldFailToGetSizeOfAbsentValue(final Storage storage) {
-        final BlockingStorage blocking = new BlockingStorage(storage);
-        final Key key = new Key.From("shouldFailToGetSizeOfAbsentValue");
-        Assertions.assertThrows(RuntimeException.class, () -> blocking.size(key));
+        final CompletableFuture<Long> size = storage.size(
+            new Key.From("shouldFailToGetSizeOfAbsentValue")
+        );
+        final Exception exception = Assertions.assertThrows(
+            CompletionException.class,
+            size::join
+        );
+        MatcherAssert.assertThat(
+            exception.getCause(),
+            new IsInstanceOf(ValueNotFoundException.class)
+        );
     }
 }


### PR DESCRIPTION
Part of #260
Throwing `ValueNotFoundException` when value absent in storage. This is required to distinguish this sort of errors from others on calls to `value` and `size` methods