### PR TITLE
#284 - cache impl to load from remote

### DIFF
--- a/src/main/java/com/artipie/asto/AsyncContent.java
+++ b/src/main/java/com/artipie/asto/AsyncContent.java
@@ -43,4 +43,31 @@ public interface AsyncContent extends Supplier<CompletionStage<? extends Content
 
     @Override
     CompletionStage<? extends Content> get();
+
+    /**
+     * Failed async content.
+     * @since 0.3
+     */
+    final class Failed implements AsyncContent {
+
+        /**
+         * Failure cause.
+         */
+        private final Throwable reason;
+
+        /**
+         * Ctor.
+         * @param reason Failure cause
+         */
+        public Failed(final Throwable reason) {
+            this.reason = reason;
+        }
+
+        @Override
+        public CompletionStage<? extends Content> get() {
+            final CompletableFuture<? extends Content> res = new CompletableFuture<>();
+            res.completeExceptionally(this.reason);
+            return res;
+        }
+    }
 }

--- a/src/main/java/com/artipie/asto/AsyncContent.java
+++ b/src/main/java/com/artipie/asto/AsyncContent.java
@@ -46,7 +46,7 @@ public interface AsyncContent extends Supplier<CompletionStage<? extends Content
 
     /**
      * Failed async content.
-     * @since 0.3
+     * @since 0.30
      */
     final class Failed implements AsyncContent {
 

--- a/src/main/java/com/artipie/asto/cache/FromRemoteCache.java
+++ b/src/main/java/com/artipie/asto/cache/FromRemoteCache.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.asto.cache;
+
+import com.artipie.asto.AsyncContent;
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+/**
+ * This cache implementation loads all the items from remote and caches it to storage. Content
+ * is loaded from cache only if remote failed to return requested item.
+ * @since 0.3
+ */
+public final class FromRemoteCache implements Cache {
+
+    /**
+     * Back-end storage.
+     */
+    private final Storage storage;
+
+    /**
+     * New remote cache.
+     * @param storage Back-end storage for cache
+     */
+    public FromRemoteCache(final Storage storage) {
+        this.storage = storage;
+    }
+
+    @Override
+    public CompletionStage<? extends Content> load(
+        final Key key, final AsyncContent remote, final CacheControl control
+    ) {
+        return remote.get().handle(
+            (content, throwable) -> {
+                final CompletionStage<? extends Content> res;
+                if (throwable == null) {
+                    res = this.storage.save(key,  new Content.From(content.size(), content))
+                        .thenCompose(nothing -> this.storage.value(key));
+                } else {
+                    res = new FromStorageCache(this.storage)
+                        .load(key, new AsyncContent.Failed(throwable), control);
+                }
+                return res;
+            }
+        ).thenCompose(Function.identity());
+    }
+}

--- a/src/main/java/com/artipie/asto/cache/FromRemoteCache.java
+++ b/src/main/java/com/artipie/asto/cache/FromRemoteCache.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
 /**
  * This cache implementation loads all the items from remote and caches it to storage. Content
  * is loaded from cache only if remote failed to return requested item.
- * @since 0.3
+ * @since 0.30
  */
 public final class FromRemoteCache implements Cache {
 

--- a/src/main/java/com/artipie/asto/cache/FromStorageCache.java
+++ b/src/main/java/com/artipie/asto/cache/FromStorageCache.java
@@ -33,7 +33,7 @@ import hu.akarnokd.rxjava2.interop.SingleInterop;
 import java.util.concurrent.CompletionStage;
 
 /**
- * Cache implementation that trays to obtain items from storage cache,
+ * Cache implementation that tries to obtain items from storage cache,
  * validates it and returns if valid. If item is not present in storage or is not valid,
  * it is loaded from remote.
  * @since 0.24

--- a/src/main/java/com/artipie/asto/cache/FromStorageCache.java
+++ b/src/main/java/com/artipie/asto/cache/FromStorageCache.java
@@ -33,10 +33,12 @@ import hu.akarnokd.rxjava2.interop.SingleInterop;
 import java.util.concurrent.CompletionStage;
 
 /**
- * Storage cache implementation.
+ * Cache implementation that trays to obtain items from storage cache,
+ * validates it and returns if valid. If item is not present in storage or is not valid,
+ * it is loaded from remote.
  * @since 0.24
  */
-public final class StorageCache implements Cache {
+public final class FromStorageCache implements Cache {
 
     /**
      * Back-end storage.
@@ -47,7 +49,7 @@ public final class StorageCache implements Cache {
      * New storage cache.
      * @param storage Back-end storage for cache
      */
-    public StorageCache(final Storage storage) {
+    public FromStorageCache(final Storage storage) {
         this.storage = storage;
     }
 

--- a/src/test/java/com/artipie/asto/cache/FromRemoteCacheTest.java
+++ b/src/test/java/com/artipie/asto/cache/FromRemoteCacheTest.java
@@ -1,0 +1,123 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.asto.cache;
+
+import com.artipie.asto.AsyncContent;
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.ext.PublisherAs;
+import com.artipie.asto.memory.InMemoryStorage;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link FromRemoteCache}.
+ * @since 0.3
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+final class FromRemoteCacheTest {
+
+    /**
+     * Test storage.
+     */
+    private Storage storage;
+
+    /**
+     * Test cache.
+     */
+    private Cache cache;
+
+    @BeforeEach
+    void setUp() {
+        this.storage = new InMemoryStorage();
+        this.cache = new FromRemoteCache(this.storage);
+    }
+
+    @Test
+    void obtainsItemFromRemoteAndCaches() {
+        final byte[] content = "123".getBytes();
+        final Key key = new Key.From("item");
+        MatcherAssert.assertThat(
+            "Returns content from remote",
+            new PublisherAs(
+                this.cache.load(
+                    key,
+                    () -> CompletableFuture.completedFuture(new Content.From(content)),
+                    CacheControl.Standard.ALWAYS
+                ).toCompletableFuture().join()
+            ).bytes().toCompletableFuture().join(),
+            new IsEqual<>(content)
+        );
+        MatcherAssert.assertThat(
+            "Saves to storage",
+            new PublisherAs(this.storage.value(key).join()).bytes().toCompletableFuture().join(),
+            new IsEqual<>(content)
+        );
+    }
+
+    @Test
+    void loadsFromCacheWhenObtainFromRemoteFailed() {
+        final byte[] content = "098".getBytes();
+        final Key key = new Key.From("some");
+        this.storage.save(key, new Content.From(content)).join();
+        MatcherAssert.assertThat(
+            "Returns content from storage",
+            new PublisherAs(
+                this.cache.load(
+                    key,
+                    new AsyncContent.Failed(new IOException("IO error")),
+                    CacheControl.Standard.ALWAYS
+                ).toCompletableFuture().join()
+            ).bytes().toCompletableFuture().join(),
+            new IsEqual<>(content)
+        );
+    }
+
+    @Test
+    void failsIfRemoteNotAvailableAndItemIsNotValid() {
+        final Key key = new Key.From("any");
+        this.storage.save(key, Content.EMPTY).join();
+        MatcherAssert.assertThat(
+            Assertions.assertThrows(
+                CompletionException.class,
+                () -> this.cache.load(
+                    key,
+                    new AsyncContent.Failed(new ConnectException("Not available")),
+                    CacheControl.Standard.NO_CACHE
+                ).toCompletableFuture().join()
+            ).getCause(),
+            new IsInstanceOf(ConnectException.class)
+        );
+    }
+
+}

--- a/src/test/java/com/artipie/asto/cache/FromRemoteCacheTest.java
+++ b/src/test/java/com/artipie/asto/cache/FromRemoteCacheTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link FromRemoteCache}.
- * @since 0.3
+ * @since 0.30
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class FromRemoteCacheTest {

--- a/src/test/java/com/artipie/asto/cache/FromStorageCacheTest.java
+++ b/src/test/java/com/artipie/asto/cache/FromStorageCacheTest.java
@@ -44,7 +44,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for {@link StorageCache}.
+ * Test case for {@link FromStorageCache}.
  *
  * @since 0.24
  * @checkstyle MagicNumberCheck (500 lines)
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.Test;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-final class StorageCacheTest {
+final class FromStorageCacheTest {
 
     /**
      * Storage for tests.
@@ -65,7 +65,7 @@ final class StorageCacheTest {
         final byte[] data = "hello1".getBytes();
         new BlockingStorage(this.storage).save(key, data);
         MatcherAssert.assertThat(
-            new StorageCache(this.storage).load(
+            new FromStorageCache(this.storage).load(
                 key,
                 () -> CompletableFuture.supplyAsync(
                     () -> {
@@ -82,7 +82,7 @@ final class StorageCacheTest {
     void savesToCacheFromRemote() throws Exception {
         final Key key = new Key.From("key2");
         final byte[] data = "hello2".getBytes();
-        final StorageCache cache = new StorageCache(this.storage);
+        final FromStorageCache cache = new FromStorageCache(this.storage);
         final Content load = cache.load(
             key,
             () -> CompletableFuture.supplyAsync(() -> new Content.From(data)),
@@ -111,7 +111,7 @@ final class StorageCacheTest {
     void dontCacheFailedRemote() throws Exception {
         final Key key = new Key.From("key3");
         final AtomicInteger cnt = new AtomicInteger();
-        new StorageCache(this.storage).load(
+        new FromStorageCache(this.storage).load(
             key,
             () -> CompletableFuture.supplyAsync(
                 () -> new Content.From(
@@ -140,7 +140,7 @@ final class StorageCacheTest {
 
     @Test
     void processMultipleRequestsSimultaneously() throws Exception {
-        final StorageCache cache = new StorageCache(this.storage);
+        final FromStorageCache cache = new FromStorageCache(this.storage);
         final Key key = new Key.From("key4");
         final int count = 100;
         final CountDownLatch latch = new CountDownLatch(10);


### PR DESCRIPTION
Closes #284 
Added implementation of `Cache` to always load content from remote and add to storage and get from cache only if remote failed to return content.