### PR TITLE
#286 - changed Cache to use Remote

### DIFF
--- a/src/main/java/com/artipie/asto/cache/Cache.java
+++ b/src/main/java/com/artipie/asto/cache/Cache.java
@@ -23,9 +23,9 @@
  */
 package com.artipie.asto.cache;
 
-import com.artipie.asto.AsyncContent;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -49,7 +49,7 @@ public interface Cache {
      * @param control Cache control
      * @return Content for key
      */
-    CompletionStage<? extends Content> load(
-        Key key, AsyncContent remote, CacheControl control
+    CompletionStage<Optional<? extends Content>> load(
+        Key key, Remote remote, CacheControl control
     );
 }

--- a/src/main/java/com/artipie/asto/cache/FromRemoteCache.java
+++ b/src/main/java/com/artipie/asto/cache/FromRemoteCache.java
@@ -59,12 +59,18 @@ public final class FromRemoteCache implements Cache {
                 final CompletionStage<Optional<? extends Content>> res;
                 if (throwable == null && content.isPresent()) {
                     res = this.storage.save(
-                        key,  new Content.From(content.get().size(), content.get())
+                        key, new Content.From(content.get().size(), content.get())
                     ).thenCompose(nothing -> this.storage.value(key))
                         .thenApply(Optional::of);
                 } else {
+                    final Throwable error;
+                    if (throwable == null) {
+                        error = new IllegalStateException("Failed to load content from remote");
+                    } else {
+                        error = throwable;
+                    }
                     res = new FromStorageCache(this.storage)
-                        .load(key, new Remote.Failed(throwable), control);
+                        .load(key, new Remote.Failed(error), control);
                 }
                 return res;
             }

--- a/src/main/java/com/artipie/asto/cache/FromRemoteCache.java
+++ b/src/main/java/com/artipie/asto/cache/FromRemoteCache.java
@@ -23,10 +23,10 @@
  */
 package com.artipie.asto.cache;
 
-import com.artipie.asto.AsyncContent;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
@@ -51,18 +51,20 @@ public final class FromRemoteCache implements Cache {
     }
 
     @Override
-    public CompletionStage<? extends Content> load(
-        final Key key, final AsyncContent remote, final CacheControl control
+    public CompletionStage<Optional<? extends Content>> load(
+        final Key key, final Remote remote, final CacheControl control
     ) {
         return remote.get().handle(
             (content, throwable) -> {
-                final CompletionStage<? extends Content> res;
-                if (throwable == null) {
-                    res = this.storage.save(key,  new Content.From(content.size(), content))
-                        .thenCompose(nothing -> this.storage.value(key));
+                final CompletionStage<Optional<? extends Content>> res;
+                if (throwable == null && content.isPresent()) {
+                    res = this.storage.save(
+                        key,  new Content.From(content.get().size(), content.get())
+                    ).thenCompose(nothing -> this.storage.value(key))
+                        .thenApply(Optional::of);
                 } else {
                     res = new FromStorageCache(this.storage)
-                        .load(key, new AsyncContent.Failed(throwable), control);
+                        .load(key, new Remote.Failed(throwable), control);
                 }
                 return res;
             }

--- a/src/main/java/com/artipie/asto/cache/Remote.java
+++ b/src/main/java/com/artipie/asto/cache/Remote.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
  * Async {@link java.util.function.Supplier} of {@link java.util.concurrent.CompletionStage}
  * with {@link Optional} of {@link Content}. It's a {@link FunctionalInterface}.
  *
- * @since 0.40
+ * @since 0.32
  */
 @FunctionalInterface
 public interface Remote extends Supplier<CompletionStage<Optional<? extends Content>>> {
@@ -45,7 +45,7 @@ public interface Remote extends Supplier<CompletionStage<Optional<? extends Cont
     /**
      * Implementation of {@link Remote} that handle all possible errors and returns
      * empty {@link Optional} if any exception happened.
-     * @since 0.40
+     * @since 0.32
      */
     class WithErrorHandling implements Remote {
 
@@ -81,7 +81,7 @@ public interface Remote extends Supplier<CompletionStage<Optional<? extends Cont
 
     /**
      * Failed remote.
-     * @since 0.40
+     * @since 0.32
      */
     final class Failed implements Remote {
 

--- a/src/main/java/com/artipie/asto/cache/Remote.java
+++ b/src/main/java/com/artipie/asto/cache/Remote.java
@@ -26,6 +26,7 @@ package com.artipie.asto.cache;
 import com.artipie.asto.Content;
 import com.jcabi.log.Logger;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
@@ -33,7 +34,7 @@ import java.util.function.Supplier;
  * Async {@link java.util.function.Supplier} of {@link java.util.concurrent.CompletionStage}
  * with {@link Optional} of {@link Content}. It's a {@link FunctionalInterface}.
  *
- * @since 0.4
+ * @since 0.40
  */
 @FunctionalInterface
 public interface Remote extends Supplier<CompletionStage<Optional<? extends Content>>> {
@@ -44,7 +45,7 @@ public interface Remote extends Supplier<CompletionStage<Optional<? extends Cont
     /**
      * Implementation of {@link Remote} that handle all possible errors and returns
      * empty {@link Optional} if any exception happened.
-     * @since 0.4
+     * @since 0.40
      */
     class WithErrorHandling implements Remote {
 
@@ -75,6 +76,33 @@ public interface Remote extends Supplier<CompletionStage<Optional<? extends Cont
                     return res;
                 }
             );
+        }
+    }
+
+    /**
+     * Failed remote.
+     * @since 0.40
+     */
+    final class Failed implements Remote {
+
+        /**
+         * Failure cause.
+         */
+        private final Throwable reason;
+
+        /**
+         * Ctor.
+         * @param reason Failure cause
+         */
+        public Failed(final Throwable reason) {
+            this.reason = reason;
+        }
+
+        @Override
+        public CompletionStage<Optional<? extends Content>> get() {
+            final CompletableFuture<Optional<? extends Content>> res = new CompletableFuture<>();
+            res.completeExceptionally(this.reason);
+            return res;
         }
     }
 }

--- a/src/test/java/com/artipie/asto/cache/FromRemoteCacheTest.java
+++ b/src/test/java/com/artipie/asto/cache/FromRemoteCacheTest.java
@@ -86,6 +86,24 @@ final class FromRemoteCacheTest {
     }
 
     @Test
+    void obtainsItemFromCacheIfRemoteValueIsAbsent() {
+        final byte[] content = "765".getBytes();
+        final Key key = new Key.From("key");
+        this.storage.save(key, new Content.From(content)).join();
+        MatcherAssert.assertThat(
+            "Returns content from cache",
+            new PublisherAs(
+                this.cache.load(
+                    key,
+                    () -> CompletableFuture.completedFuture(Optional.empty()),
+                    CacheControl.Standard.ALWAYS
+                ).toCompletableFuture().join().get()
+            ).bytes().toCompletableFuture().join(),
+            new IsEqual<>(content)
+        );
+    }
+
+    @Test
     void loadsFromCacheWhenObtainFromRemoteFailed() {
         final byte[] content = "098".getBytes();
         final Key key = new Key.From("some");

--- a/src/test/java/com/artipie/asto/cache/FromRemoteCacheTest.java
+++ b/src/test/java/com/artipie/asto/cache/FromRemoteCacheTest.java
@@ -23,7 +23,6 @@
  */
 package com.artipie.asto.cache;
 
-import com.artipie.asto.AsyncContent;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -31,6 +30,7 @@ import com.artipie.asto.ext.PublisherAs;
 import com.artipie.asto.memory.InMemoryStorage;
 import java.io.IOException;
 import java.net.ConnectException;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import org.hamcrest.MatcherAssert;
@@ -72,9 +72,9 @@ final class FromRemoteCacheTest {
             new PublisherAs(
                 this.cache.load(
                     key,
-                    () -> CompletableFuture.completedFuture(new Content.From(content)),
+                    () -> CompletableFuture.completedFuture(Optional.of(new Content.From(content))),
                     CacheControl.Standard.ALWAYS
-                ).toCompletableFuture().join()
+                ).toCompletableFuture().join().get()
             ).bytes().toCompletableFuture().join(),
             new IsEqual<>(content)
         );
@@ -95,9 +95,9 @@ final class FromRemoteCacheTest {
             new PublisherAs(
                 this.cache.load(
                     key,
-                    new AsyncContent.Failed(new IOException("IO error")),
+                    new Remote.Failed(new IOException("IO error")),
                     CacheControl.Standard.ALWAYS
-                ).toCompletableFuture().join()
+                ).toCompletableFuture().join().get()
             ).bytes().toCompletableFuture().join(),
             new IsEqual<>(content)
         );
@@ -112,7 +112,7 @@ final class FromRemoteCacheTest {
                 CompletionException.class,
                 () -> this.cache.load(
                     key,
-                    new AsyncContent.Failed(new ConnectException("Not available")),
+                    new Remote.Failed(new ConnectException("Not available")),
                     CacheControl.Standard.NO_CACHE
                 ).toCompletableFuture().join()
             ).getCause(),

--- a/src/test/java/com/artipie/asto/cache/FromStorageCacheTest.java
+++ b/src/test/java/com/artipie/asto/cache/FromStorageCacheTest.java
@@ -41,7 +41,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/src/test/java/com/artipie/asto/cache/FromStorageCacheTest.java
+++ b/src/test/java/com/artipie/asto/cache/FromStorageCacheTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/src/test/java/com/artipie/asto/cache/RemoteWithErrorHandlingTest.java
+++ b/src/test/java/com/artipie/asto/cache/RemoteWithErrorHandlingTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link Remote.WithErrorHandling}.
- * @since 0.4
+ * @since 0.32
  */
 class RemoteWithErrorHandlingTest {
 


### PR DESCRIPTION
Part of #286 
Changed `Cache` signature to use `Remote`, corrected implementations and added `Remote.Failed`.