### PR TITLE
Check ROOT key for save and load

### DIFF
--- a/src/main/java/com/artipie/asto/SubStorage.java
+++ b/src/main/java/com/artipie/asto/SubStorage.java
@@ -24,6 +24,7 @@
 package com.artipie.asto;
 
 import com.artipie.asto.lock.storage.StorageLock;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -81,7 +82,14 @@ public final class SubStorage implements Storage {
 
     @Override
     public CompletableFuture<Void> save(final Key key, final Content content) {
-        return this.origin.save(new PrefixedKed(this.prefix, key), content);
+        final CompletableFuture<Void> res;
+        if (Key.ROOT.equals(key)) {
+            res = CompletableFuture.<Void>failedStage(new IOException("Unable to save to root"))
+                .toCompletableFuture();
+        } else {
+            res = this.origin.save(new PrefixedKed(this.prefix, key), content);
+        }
+        return res;
     }
 
     @Override

--- a/src/main/java/com/artipie/asto/SubStorage.java
+++ b/src/main/java/com/artipie/asto/SubStorage.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.asto;
 
+import com.artipie.asto.ext.CompletableFutureSupport;
 import com.artipie.asto.lock.storage.StorageLock;
 import java.io.IOException;
 import java.util.Collection;
@@ -84,8 +85,9 @@ public final class SubStorage implements Storage {
     public CompletableFuture<Void> save(final Key key, final Content content) {
         final CompletableFuture<Void> res;
         if (Key.ROOT.equals(key)) {
-            res = CompletableFuture.<Void>failedStage(new IOException("Unable to save to root"))
-                .toCompletableFuture();
+            res = new CompletableFutureSupport.Failed<Void>(
+                new IOException("Unable to save to root")
+            ).get();
         } else {
             res = this.origin.save(new PrefixedKed(this.prefix, key), content);
         }

--- a/src/main/java/com/artipie/asto/ext/CompletableFutureSupport.java
+++ b/src/main/java/com/artipie/asto/ext/CompletableFutureSupport.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.artipie.asto.ext;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+/**
+ * Support of new {@link CompletableFuture} API for JDK 1.8.
+ * @param <T> Future type
+ * @since 0.33
+ */
+public abstract class CompletableFutureSupport<T> implements Supplier<CompletableFuture<T>> {
+
+    /**
+     * Supplier wrap.
+     */
+    private final Supplier<? extends CompletableFuture<T>> wrap;
+
+    /**
+     * New wrapped future supplier.
+     * @param wrap Supplier to wrap
+     */
+    protected CompletableFutureSupport(final Supplier<? extends CompletableFuture<T>> wrap) {
+        this.wrap = wrap;
+    }
+
+    @Override
+    public final CompletableFuture<T> get() {
+        return this.wrap.get();
+    }
+
+    /**
+     * Failed completable future supplier.
+     * @param <T> Future type
+     * @since 0.33
+     */
+    public static final class Failed<T> extends CompletableFutureSupport<T> {
+        /**
+         * New failed future.
+         * @param err Failure exception
+         */
+        public Failed(final Exception err) {
+            super(() -> {
+                final CompletableFuture<T> future = new CompletableFuture<>();
+                future.completeExceptionally(err);
+                return future;
+            });
+        }
+    }
+
+}

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -29,6 +29,7 @@ import com.artipie.asto.OneTimePublisher;
 import com.artipie.asto.Storage;
 import com.artipie.asto.UnderLockOperation;
 import com.artipie.asto.ValueNotFoundException;
+import com.artipie.asto.ext.CompletableFutureSupport;
 import com.artipie.asto.lock.storage.StorageLock;
 import com.jcabi.log.Logger;
 import java.io.IOException;
@@ -232,9 +233,9 @@ public final class FileStorage implements Storage {
     public CompletableFuture<Content> value(final Key key) {
         final CompletableFuture<Content> res;
         if (Key.ROOT.equals(key)) {
-            res = CompletableFuture.<Content>failedStage(
+            res = new CompletableFutureSupport.Failed<Content>(
                 new IOException("Unable to load from root")
-            ).toCompletableFuture();
+            ).get();
         } else {
             res = this.size(key).thenApply(
                 size -> new Content.OneTime(

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -230,11 +230,19 @@ public final class FileStorage implements Storage {
 
     @Override
     public CompletableFuture<Content> value(final Key key) {
-        return this.size(key).thenApply(
-            size -> new Content.OneTime(
-                new Content.From(size, new File(this.path(key)).content(this.exec))
-            )
-        );
+        final CompletableFuture<Content> res;
+        if (Key.ROOT.equals(key)) {
+            res = CompletableFuture.<Content>failedStage(
+                new IOException("Unable to load from root")
+            ).toCompletableFuture();
+        } else {
+            res = this.size(key).thenApply(
+                size -> new Content.OneTime(
+                    new Content.From(size, new File(this.path(key)).content(this.exec))
+                )
+            );
+        }
+        return res;
     }
 
     @Override

--- a/src/main/java/com/artipie/asto/fs/VertxFileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/VertxFileStorage.java
@@ -216,15 +216,23 @@ public final class VertxFileStorage implements Storage {
 
     @Override
     public CompletableFuture<Content> value(final Key key) {
-        return this.size(key).thenApply(
-            size ->
-                new Content.OneTime(
-                    new Content.From(
-                        size,
-                        new VertxRxFile(this.path(key), this.vertx).flow()
+        final CompletableFuture<Content> res;
+        if (Key.ROOT.equals(key)) {
+            res = CompletableFuture.<Content>failedStage(
+                new IOException("Unable to load from root")
+            ).toCompletableFuture();
+        } else {
+            res = this.size(key).thenApply(
+                size ->
+                    new Content.OneTime(
+                        new Content.From(
+                            size,
+                            new VertxRxFile(this.path(key), this.vertx).flow()
+                        )
                     )
-                )
-        );
+            );
+        }
+        return res;
     }
 
     @Override

--- a/src/main/java/com/artipie/asto/fs/VertxFileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/VertxFileStorage.java
@@ -28,6 +28,7 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.UnderLockOperation;
 import com.artipie.asto.ValueNotFoundException;
+import com.artipie.asto.ext.CompletableFutureSupport;
 import com.artipie.asto.lock.storage.StorageLock;
 import com.jcabi.log.Logger;
 import hu.akarnokd.rxjava2.interop.CompletableInterop;
@@ -218,9 +219,9 @@ public final class VertxFileStorage implements Storage {
     public CompletableFuture<Content> value(final Key key) {
         final CompletableFuture<Content> res;
         if (Key.ROOT.equals(key)) {
-            res = CompletableFuture.<Content>failedStage(
+            res = new CompletableFutureSupport.Failed<Content>(
                 new IOException("Unable to load from root")
-            ).toCompletableFuture();
+            ).get();
         } else {
             res = this.size(key).thenApply(
                 size ->

--- a/src/main/java/com/artipie/asto/memory/InMemoryStorage.java
+++ b/src/main/java/com/artipie/asto/memory/InMemoryStorage.java
@@ -31,6 +31,7 @@ import com.artipie.asto.Remaining;
 import com.artipie.asto.Storage;
 import com.artipie.asto.UnderLockOperation;
 import com.artipie.asto.ValueNotFoundException;
+import com.artipie.asto.ext.CompletableFutureSupport;
 import com.artipie.asto.lock.storage.StorageLock;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import java.io.IOException;
@@ -98,8 +99,9 @@ public final class InMemoryStorage implements Storage {
     public CompletableFuture<Void> save(final Key key, final Content content) {
         final CompletableFuture<Void> res;
         if (Key.ROOT.equals(key)) {
-            res = CompletableFuture.<Void>failedStage(new IOException("Unable to save to root"))
-                .toCompletableFuture();
+            res = new CompletableFutureSupport.Failed<Void>(
+                new IOException("Unable to save to root")
+            ).get();
         } else {
             res = new Concatenation(new OneTimePublisher<>(content)).single()
                 .to(SingleInterop.get())
@@ -153,9 +155,9 @@ public final class InMemoryStorage implements Storage {
     public CompletableFuture<Content> value(final Key key) {
         final CompletableFuture<Content> res;
         if (Key.ROOT.equals(key)) {
-            res = CompletableFuture.<Content>failedStage(
+            res = new CompletableFutureSupport.Failed<Content>(
                 new IOException("Unable to load from root")
-            ).toCompletableFuture();
+            ).get();
         } else {
             res = CompletableFuture.supplyAsync(
                 () -> {

--- a/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
+++ b/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
@@ -28,6 +28,7 @@ import io.reactivex.Flowable;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
@@ -43,7 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @checkstyle IllegalCatchCheck (500 lines)
  * @since 0.14
  */
-@SuppressWarnings("PMD.AvoidCatchingGenericException")
+@SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.TooManyMethods"})
 @ExtendWith(StorageExtension.class)
 public final class StorageSaveAndLoadTest {
 
@@ -216,6 +217,28 @@ public final class StorageSaveAndLoadTest {
         MatcherAssert.assertThat(
             storage.value(key).get().size().get(),
             new IsEqual<>((long) content.length)
+        );
+    }
+
+    @TestTemplate
+    void saveDoesNotSupportRootKey(final Storage storage) throws Exception {
+        Assertions.assertThrows(
+            ExecutionException.class, () -> storage.save(Key.ROOT, Content.EMPTY).get(),
+            String.format(
+                "`%s` storage didn't fail on root saving",
+                storage.getClass().getSimpleName()
+            )
+        );
+    }
+
+    @TestTemplate
+    void loadDoesnNotSupportRootKey(final Storage storage) throws Exception {
+        Assertions.assertThrows(
+            ExecutionException.class, () -> storage.value(Key.ROOT).get(),
+            String.format(
+                "`%s` storage didn't fail on root loading",
+                storage.getClass().getSimpleName()
+            )
         );
     }
 }


### PR DESCRIPTION
Closes #201 - added check for `ROOT` key in `save` and `value` storage
methods:
 - added tests to find all problem methods in `StorageSaveAndLoadTest`
 - fixed all `Storage` implementation to fail on `ROOT` key