### PR TITLE
Do not throw `NoSuchFileException` while removing empty dirs in `FileStorage`

### DIFF
--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -260,7 +260,7 @@ public final class FileStorage implements Storage {
                 try {
                     try (Stream<Path> files = Files.list(path)) {
                         if (!files.findFirst().isPresent()) {
-                            Files.delete(path);
+                            Files.deleteIfExists(path);
                             again = true;
                         }
                     }


### PR DESCRIPTION
Closes #307 
Corrected `FileStorage#deleteEmptyParts()` not to throw `NoSuchFileException` if empty folder we are going to remove does not exist.