### PR TITLE
Added artipie base exception classes

### DIFF
--- a/src/main/java/com/artipie/ArtipieException.java
+++ b/src/main/java/com/artipie/ArtipieException.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie;
+
+/**
+ * Base Artipie exception.
+ * <p>It should be used as a base exception for all Artipie public APIs
+ * as a contract instead of others.</p>
+ *
+ * @since 1.0
+ * @implNote ArtipieException is unchecked exception, but it's a good
+ *  practice to document it via {@code throws} tag in JavaDocs.
+ */
+public class ArtipieException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * New exception with message and base cause.
+     * @param msg Message
+     * @param cause Cause
+     */
+    public ArtipieException(final String msg, final Throwable cause) {
+        super(msg, cause);
+    }
+
+    /**
+     * New exception with base cause.
+     * @param cause Cause
+     */
+    public ArtipieException(final Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * New exception with message.
+     * @param msg Message
+     */
+    public ArtipieException(final String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/artipie/asto/ArtipieIOException.java
+++ b/src/main/java/com/artipie/asto/ArtipieIOException.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto;
+
+import com.artipie.ArtipieException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/**
+ * Artipie input-output exception.
+ * @since 1.0
+ * @checkstyle AbbreviationAsWordInNameCheck (10 lines)
+ */
+public class ArtipieIOException extends ArtipieException {
+
+    private static final long serialVersionUID = 862160427262047490L;
+
+    /**
+     * New IO excption.
+     * @param cause IO exception
+     */
+    public ArtipieIOException(final IOException cause) {
+        super(cause);
+    }
+
+    /**
+     * New IO excption with message.
+     * @param msg Message
+     * @param cause IO exception
+     */
+    public ArtipieIOException(final String msg, final IOException cause) {
+        super(msg, cause);
+    }
+
+    /**
+     * New IO exception.
+     * @param cause Unkown exception
+     */
+    public ArtipieIOException(final Throwable cause) {
+        this(ArtipieIOException.unwrap(cause));
+    }
+
+    /**
+     * New IO exception.
+     * @param msg Exception message
+     * @param cause Unkown exception
+     */
+    public ArtipieIOException(final String msg, final Throwable cause) {
+        this(msg, ArtipieIOException.unwrap(cause));
+    }
+
+    /**
+     * New IO exception with message.
+     * @param msg Exception message
+     */
+    public ArtipieIOException(final String msg) {
+        this(new IOException(msg));
+    }
+
+    /**
+     * Resolve unkown exception to IO exception.
+     * @param cause Unkown exception
+     * @return IO exception
+     */
+    private static IOException unwrap(final Throwable cause) {
+        final IOException iex;
+        if (cause instanceof UncheckedIOException) {
+            iex = ((UncheckedIOException) cause).getCause();
+        } else if (cause instanceof IOException) {
+            iex = (IOException) cause;
+        } else {
+            iex = new IOException(cause);
+        }
+        return iex;
+    }
+}

--- a/src/main/java/com/artipie/asto/Key.java
+++ b/src/main/java/com/artipie/asto/Key.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.asto;
 
+import com.artipie.ArtipieException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -150,10 +151,10 @@ public interface Key {
         public String string() {
             for (final String part : this.parts) {
                 if (part.isEmpty()) {
-                    throw new IllegalStateException("Empty parts are not allowed");
+                    throw new ArtipieException("Empty parts are not allowed");
                 }
                 if (part.contains(From.DELIMITER)) {
-                    throw new IllegalStateException(String.format("Invalid part: '%s'", part));
+                    throw new ArtipieException(String.format("Invalid part: '%s'", part));
                 }
             }
             return String.join(From.DELIMITER, this.parts);

--- a/src/main/java/com/artipie/asto/OneTimePublisher.java
+++ b/src/main/java/com/artipie/asto/OneTimePublisher.java
@@ -55,7 +55,7 @@ public final class OneTimePublisher<T> implements Publisher<T> {
                     }
                 }
             );
-            sub.onError(new IllegalStateException(String.format(msg, subs)));
+            sub.onError(new ArtipieIOException(String.format(msg, subs)));
         }
     }
 }

--- a/src/main/java/com/artipie/asto/SubStorage.java
+++ b/src/main/java/com/artipie/asto/SubStorage.java
@@ -6,7 +6,6 @@ package com.artipie.asto;
 
 import com.artipie.asto.ext.CompletableFutureSupport;
 import com.artipie.asto.lock.storage.StorageLock;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -67,7 +66,7 @@ public final class SubStorage implements Storage {
         final CompletableFuture<Void> res;
         if (Key.ROOT.equals(key)) {
             res = new CompletableFutureSupport.Failed<Void>(
-                new IOException("Unable to save to root")
+                new ArtipieIOException("Unable to save to root")
             ).get();
         } else {
             res = this.origin.save(new PrefixedKed(this.prefix, key), content);

--- a/src/main/java/com/artipie/asto/ValueNotFoundException.java
+++ b/src/main/java/com/artipie/asto/ValueNotFoundException.java
@@ -4,13 +4,15 @@
  */
 package com.artipie.asto;
 
+import java.io.IOException;
+
 /**
  * Exception indicating that value cannot be found in storage.
  *
  * @since 0.28
  */
 @SuppressWarnings("serial")
-public class ValueNotFoundException extends RuntimeException {
+public class ValueNotFoundException extends ArtipieIOException {
 
     /**
      * Ctor.
@@ -28,7 +30,7 @@ public class ValueNotFoundException extends RuntimeException {
      * @param cause Original cause for exception.
      */
     public ValueNotFoundException(final Key key, final Throwable cause) {
-        super(message(key), cause);
+        super(new IOException(message(key), cause));
     }
 
     /**

--- a/src/main/java/com/artipie/asto/cache/FromRemoteCache.java
+++ b/src/main/java/com/artipie/asto/cache/FromRemoteCache.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.asto.cache;
 
+import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -46,7 +47,7 @@ public final class FromRemoteCache implements Cache {
                 } else {
                     final Throwable error;
                     if (throwable == null) {
-                        error = new IllegalStateException("Failed to load content from remote");
+                        error = new ArtipieIOException("Failed to load content from remote");
                     } else {
                         error = throwable;
                     }

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.asto.fs;
 
+import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.OneTimePublisher;
@@ -14,7 +15,6 @@ import com.artipie.asto.ext.CompletableFutureSupport;
 import com.artipie.asto.lock.storage.StorageLock;
 import com.jcabi.log.Logger;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -105,7 +105,7 @@ public final class FileStorage implements Storage {
                             .sorted(Comparator.comparing(Key.From::string))
                             .collect(Collectors.toList());
                     } catch (final IOException iex) {
-                        throw new UncheckedIOException(iex);
+                        throw new ArtipieIOException(iex);
                     }
                 } else {
                     keys = Collections.emptyList();
@@ -146,7 +146,7 @@ public final class FileStorage implements Storage {
                     if (throwable == null) {
                         result.complete(null);
                     } else {
-                        result.completeExceptionally(throwable);
+                        result.completeExceptionally(new ArtipieIOException(throwable));
                     }
                     return result;
                 }
@@ -169,7 +169,7 @@ public final class FileStorage implements Storage {
                         Files.delete(path);
                         this.deleteEmptyParts(key.parent());
                     } catch (final IOException iex) {
-                        throw new UncheckedIOException(iex);
+                        throw new ArtipieIOException(iex);
                     }
                 } else {
                     throw new ValueNotFoundException(key);
@@ -187,7 +187,7 @@ public final class FileStorage implements Storage {
                 } catch (final NoSuchFileException nofile) {
                     throw new ValueNotFoundException(key, nofile);
                 } catch (final IOException iex) {
-                    throw new UncheckedIOException(iex);
+                    throw new ArtipieIOException(iex);
                 }
             }
         );
@@ -198,7 +198,7 @@ public final class FileStorage implements Storage {
         final CompletableFuture<Content> res;
         if (Key.ROOT.equals(key)) {
             res = new CompletableFutureSupport.Failed<Content>(
-                new IOException("Unable to load from root")
+                new ArtipieIOException("Unable to load from root")
             ).get();
         } else {
             res = this.size(key).thenApply(
@@ -249,7 +249,7 @@ public final class FileStorage implements Storage {
                         this.deleteEmptyParts(key.get().parent());
                     }
                 } catch (final IOException err) {
-                    throw new UncheckedIOException(err);
+                    throw new ArtipieIOException(err);
                 }
             }
         }
@@ -273,7 +273,7 @@ public final class FileStorage implements Storage {
                 try {
                     Files.move(source, dst, StandardCopyOption.REPLACE_EXISTING);
                 } catch (final IOException iex) {
-                    throw new UncheckedIOException(iex);
+                    throw new ArtipieIOException(iex);
                 }
             }
         );

--- a/src/main/java/com/artipie/asto/fs/RxFile.java
+++ b/src/main/java/com/artipie/asto/fs/RxFile.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.asto.fs;
 
+import com.artipie.asto.ArtipieIOException;
 import hu.akarnokd.rxjava2.interop.CompletableInterop;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
@@ -92,7 +93,7 @@ public class RxFile {
                             Files.move(this.file, target, StandardCopyOption.REPLACE_EXISTING);
                             res.onComplete();
                         } catch (final IOException iex) {
-                            res.onError(iex);
+                            res.onError(new ArtipieIOException(iex));
                         }
                     }
                 );
@@ -116,7 +117,7 @@ public class RxFile {
                             Files.delete(this.file);
                             res.onComplete();
                         } catch (final IOException iex) {
-                            res.onError(iex);
+                            res.onError(new ArtipieIOException(iex));
                         }
                     }
                 );
@@ -139,7 +140,7 @@ public class RxFile {
                         try {
                             res.onSuccess(Files.size(this.file));
                         } catch (final IOException iex) {
-                            res.onError(iex);
+                            res.onError(new ArtipieIOException(iex));
                         }
                     }
                 );

--- a/src/main/java/com/artipie/asto/fs/VertxFileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/VertxFileStorage.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.asto.fs;
 
+import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -21,7 +22,6 @@ import io.vertx.core.file.CopyOptions;
 import io.vertx.reactivex.RxHelper;
 import io.vertx.reactivex.core.Vertx;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -102,7 +102,7 @@ public final class VertxFileStorage implements Storage {
                             .sorted(Comparator.comparing(Key.From::string))
                             .collect(Collectors.toList());
                     } catch (final IOException iex) {
-                        throw new UncheckedIOException(iex);
+                        throw new ArtipieIOException(iex);
                     }
                 } else {
                     keys = Collections.emptyList();
@@ -189,7 +189,7 @@ public final class VertxFileStorage implements Storage {
                 } catch (final NoSuchFileException nofile) {
                     throw new ValueNotFoundException(key, nofile);
                 } catch (final IOException iex) {
-                    throw new UncheckedIOException(iex);
+                    throw new ArtipieIOException(iex);
                 }
             }
         ).subscribeOn(RxHelper.blockingScheduler(this.vertx.getDelegate()))
@@ -201,7 +201,7 @@ public final class VertxFileStorage implements Storage {
         final CompletableFuture<Content> res;
         if (Key.ROOT.equals(key)) {
             res = new CompletableFutureSupport.Failed<Content>(
-                new IOException("Unable to load from root")
+                new ArtipieIOException("Unable to load from root")
             ).get();
         } else {
             res = this.size(key).thenApply(

--- a/src/main/java/com/artipie/asto/lock/storage/Proposals.java
+++ b/src/main/java/com/artipie/asto/lock/storage/Proposals.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.asto.lock.storage;
 
+import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -80,7 +81,7 @@ final class Proposals {
                                 content -> new PublisherAs(content).asciiString().thenCompose(
                                     expiration -> {
                                         if (isNotExpired(expiration, now)) {
-                                            throw new IllegalStateException(
+                                            throw new ArtipieIOException(
                                                 String.join(
                                                     "\n",
                                                     "Failed to acquire lock.",

--- a/src/main/java/com/artipie/asto/memory/InMemoryStorage.java
+++ b/src/main/java/com/artipie/asto/memory/InMemoryStorage.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.asto.memory;
 
+import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Concatenation;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
@@ -15,7 +16,6 @@ import com.artipie.asto.ValueNotFoundException;
 import com.artipie.asto.ext.CompletableFutureSupport;
 import com.artipie.asto.lock.storage.StorageLock;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.NavigableMap;
@@ -81,7 +81,7 @@ public final class InMemoryStorage implements Storage {
         final CompletableFuture<Void> res;
         if (Key.ROOT.equals(key)) {
             res = new CompletableFutureSupport.Failed<Void>(
-                new IOException("Unable to save to root")
+                new ArtipieIOException("Unable to save to root")
             ).get();
         } else {
             res = new Concatenation(new OneTimePublisher<>(content)).single()
@@ -106,7 +106,7 @@ public final class InMemoryStorage implements Storage {
                 synchronized (this.data) {
                     final String key = source.string();
                     if (!this.data.containsKey(key)) {
-                        throw new IllegalArgumentException(
+                        throw new ArtipieIOException(
                             String.format("No value for source key: %s", source.string())
                         );
                     }
@@ -137,7 +137,7 @@ public final class InMemoryStorage implements Storage {
         final CompletableFuture<Content> res;
         if (Key.ROOT.equals(key)) {
             res = new CompletableFutureSupport.Failed<Content>(
-                new IOException("Unable to load from root")
+                new ArtipieIOException("Unable to load from root")
             ).get();
         } else {
             res = CompletableFuture.supplyAsync(
@@ -162,7 +162,7 @@ public final class InMemoryStorage implements Storage {
                 synchronized (this.data) {
                     final String str = key.string();
                     if (!this.data.containsKey(str)) {
-                        throw new IllegalArgumentException(
+                        throw new ArtipieIOException(
                             String.format("Key does not exist: %s", str)
                         );
                     }

--- a/src/main/java/com/artipie/asto/s3/EstimatedContentCompliment.java
+++ b/src/main/java/com/artipie/asto/s3/EstimatedContentCompliment.java
@@ -4,11 +4,11 @@
  */
 package com.artipie.asto.s3;
 
+import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Content;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Flowable;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -86,7 +86,7 @@ final class EstimatedContentCompliment {
                 ".upload.tmp"
             );
         } catch (final IOException ex) {
-            throw new UncheckedIOException(ex);
+            throw new ArtipieIOException(ex);
         }
         final Flowable<ByteBuffer> data = Flowable.fromPublisher(
             new File(temp).content()

--- a/src/main/java/com/artipie/asto/s3/InternalExceptionHandle.java
+++ b/src/main/java/com/artipie/asto/s3/InternalExceptionHandle.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.asto.s3;
 
+import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.FailedCompletionStage;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -56,8 +57,10 @@ final class InternalExceptionHandle<T> implements BiFunction<T, Throwable, Compl
                 result = new FailedCompletionStage<>(
                     this.convert.apply(throwable.getCause())
                 );
+            } else if (throwable instanceof CompletionException) {
+                result = new FailedCompletionStage<>(new ArtipieIOException(throwable.getCause()));
             } else {
-                result = new FailedCompletionStage<>(throwable);
+                result = new FailedCompletionStage<>(new ArtipieIOException(throwable));
             }
         }
         return result;

--- a/src/main/java/com/artipie/asto/s3/S3Storage.java
+++ b/src/main/java/com/artipie/asto/s3/S3Storage.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.asto.s3;
 
+import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Content;
 import com.artipie.asto.FailedCompletionStage;
 import com.artipie.asto.Key;
@@ -109,7 +110,7 @@ public final class S3Storage implements Storage {
                 } else if (throwable.getCause() instanceof NoSuchKeyException) {
                     exists.complete(false);
                 } else {
-                    exists.completeExceptionally(throwable);
+                    exists.completeExceptionally(new ArtipieIOException(throwable));
                 }
                 return response;
             }
@@ -236,7 +237,7 @@ public final class S3Storage implements Storage {
                     );
                 } else {
                     deleted = new FailedCompletionStage<>(
-                        new IllegalArgumentException(String.format("Key does not exist: %s", key))
+                        new ArtipieIOException(String.format("Key does not exist: %s", key))
                     );
                 }
                 return deleted;
@@ -299,7 +300,9 @@ public final class S3Storage implements Storage {
                             new CompletableFuture<>();
                         finished = promise;
                         upload.abort().whenComplete(
-                            (ignore, ex) -> promise.completeExceptionally(throwable)
+                            (ignore, ex) -> promise.completeExceptionally(
+                                new ArtipieIOException(throwable)
+                            )
                         );
                     }
                     return finished;

--- a/src/main/java/com/artipie/package-info.java
+++ b/src/main/java/com/artipie/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+
+/**
+ * Abstract base package.
+ *
+ * @since 1.0
+ */
+package com.artipie;
+

--- a/src/test/java/com/artipie/asto/OneTimePublisherTest.java
+++ b/src/test/java/com/artipie/asto/OneTimePublisherTest.java
@@ -25,7 +25,7 @@ public final class OneTimePublisherTest {
         final Integer last = pub.lastOrError().blockingGet();
         MatcherAssert.assertThat(last, new IsEqual<>(one));
         Assertions.assertThrows(
-            IllegalStateException.class,
+            ArtipieIOException.class,
             () -> pub.firstOrError().blockingGet()
         );
     }

--- a/src/test/java/com/artipie/asto/StorageExclusivelyTest.java
+++ b/src/test/java/com/artipie/asto/StorageExclusivelyTest.java
@@ -34,7 +34,7 @@ public final class StorageExclusivelyTest {
         );
         MatcherAssert.assertThat(
             completion.getCause(),
-            new IsInstanceOf(IllegalStateException.class)
+            new IsInstanceOf(ArtipieIOException.class)
         );
     }
 

--- a/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
+++ b/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
@@ -147,7 +147,7 @@ public final class StorageSaveAndLoadTest {
         final Content value = storage.value(key).join();
         Flowable.fromPublisher(value).toList().blockingGet();
         Assertions.assertThrows(
-            IllegalStateException.class,
+            ArtipieIOException.class,
             () -> Flowable.fromPublisher(value).toList().blockingGet()
         );
     }

--- a/src/test/java/com/artipie/asto/lock/storage/StorageLockTest.java
+++ b/src/test/java/com/artipie/asto/lock/storage/StorageLockTest.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.asto.lock.storage;
 
+import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -127,7 +128,7 @@ final class StorageLockTest {
         MatcherAssert.assertThat(
             "Reason for failure is IllegalStateException",
             exception.getCause(),
-            new IsInstanceOf(IllegalStateException.class)
+            new IsInstanceOf(ArtipieIOException.class)
         );
         MatcherAssert.assertThat(
             "Proposals unmodified",

--- a/src/test/java/com/artipie/asto/s3/InternalExceptionHandleTest.java
+++ b/src/test/java/com/artipie/asto/s3/InternalExceptionHandleTest.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.asto.s3;
 
+import com.artipie.asto.ArtipieIOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
@@ -41,7 +42,7 @@ final class InternalExceptionHandleTest {
     }
 
     @Test
-    void failsAsIsWhenExceptionIsUnmatched() {
+    void wrapsWithArtipieExceptionIfUnmatched() {
         final CompletableFuture<Void> future = CompletableFuture.runAsync(Assertions::fail);
         MatcherAssert.assertThat(
             Assertions.assertThrows(
@@ -56,7 +57,7 @@ final class InternalExceptionHandleTest {
                     .toCompletableFuture()
                     ::get
             ),
-            Matchers.hasProperty("cause", Matchers.isA(AssertionError.class))
+            Matchers.hasProperty("cause", Matchers.isA(ArtipieIOException.class))
         );
     }
 


### PR DESCRIPTION
Fixes #311 - added `ArtipieException` base class and
`ArtipieIOException` for `asto` module, replaced
all API-related exceptions in storage implementations and
supplementary classes with these exceptions. Updated tests
to expect correct exception types on failure.