### PR TITLE
Added consumers and functions with `ArtipieException`

### DIFF
--- a/src/main/java/com/artipie/asto/misc/UncheckedConsumer.java
+++ b/src/main/java/com/artipie/asto/misc/UncheckedConsumer.java
@@ -13,7 +13,7 @@ import java.util.function.Consumer;
  * @param <E> Error type
  * @since 1.1
  */
-public final class UncheckedConsumer<T, E extends Throwable> implements Consumer<T> {
+public final class UncheckedConsumer<T, E extends Exception> implements Consumer<T> {
 
     /**
      * Checked version.
@@ -29,12 +29,12 @@ public final class UncheckedConsumer<T, E extends Throwable> implements Consumer
     }
 
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingThrowable")
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public void accept(final T val) {
         try {
             this.checked.accept(val);
             // @checkstyle IllegalCatchCheck (1 line)
-        } catch (final Throwable err) {
+        } catch (final Exception err) {
             throw new ArtipieException(err);
         }
     }
@@ -46,7 +46,7 @@ public final class UncheckedConsumer<T, E extends Throwable> implements Consumer
      * @since 1.1
      */
     @FunctionalInterface
-    public interface Checked<T, E extends Throwable> {
+    public interface Checked<T, E extends Exception> {
 
         /**
          * Accept value.

--- a/src/main/java/com/artipie/asto/misc/UncheckedConsumer.java
+++ b/src/main/java/com/artipie/asto/misc/UncheckedConsumer.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.misc;
+
+import com.artipie.ArtipieException;
+import java.util.function.Consumer;
+
+/**
+ * Unchecked {@link Consumer}.
+ * @param <T> Consumer type
+ * @param <E> Error type
+ * @since 1.1
+ */
+public final class UncheckedConsumer<T, E extends Throwable> implements Consumer<T> {
+
+    /**
+     * Checked version.
+     */
+    private final Checked<T, E> checked;
+
+    /**
+     * Ctor.
+     * @param checked Checked func
+     */
+    public UncheckedConsumer(final Checked<T, E> checked) {
+        this.checked = checked;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
+    public void accept(final T val) {
+        try {
+            this.checked.accept(val);
+            // @checkstyle IllegalCatchCheck (1 line)
+        } catch (final Throwable err) {
+            throw new ArtipieException(err);
+        }
+    }
+
+    /**
+     * Checked version of consumer.
+     * @param <T> Consumer type
+     * @param <E> Error type
+     * @since 1.1
+     */
+    @FunctionalInterface
+    public interface Checked<T, E extends Throwable> {
+
+        /**
+         * Accept value.
+         * @param value Value to accept
+         * @throws E On error
+         */
+        void accept(T value) throws E;
+    }
+}

--- a/src/main/java/com/artipie/asto/misc/UncheckedFunc.java
+++ b/src/main/java/com/artipie/asto/misc/UncheckedFunc.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.misc;
+
+import com.artipie.ArtipieException;
+import java.util.function.Function;
+
+/**
+ * Unchecked {@link Function}.
+ * @param <T> Function type
+ * @param <R> Function return type
+ * @param <E> Error type
+ * @since 1.1
+ */
+public final class UncheckedFunc<T, R, E extends Throwable> implements Function<T, R> {
+
+    /**
+     * Checked version.
+     */
+    private final Checked<T, R, E> checked;
+
+    /**
+     * Ctor.
+     * @param checked Checked func
+     */
+    public UncheckedFunc(final Checked<T, R, E> checked) {
+        this.checked = checked;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
+    public R apply(final T val) {
+        try {
+            return this.checked.apply(val);
+            // @checkstyle IllegalCatchCheck (1 line)
+        } catch (final Throwable err) {
+            throw new ArtipieException(err);
+        }
+    }
+
+    /**
+     * Checked version of consumer.
+     * @param <T> Consumer type
+     * @param <R> Return type
+     * @param <E> Error type
+     * @since 1.1
+     */
+    @FunctionalInterface
+    public interface Checked<T, R, E extends Throwable> {
+
+        /**
+         * Apply value.
+         * @param value Value to accept
+         * @return Result
+         * @throws E On error
+         */
+        R apply(T value) throws E;
+    }
+}

--- a/src/main/java/com/artipie/asto/misc/UncheckedFunc.java
+++ b/src/main/java/com/artipie/asto/misc/UncheckedFunc.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
  * @param <E> Error type
  * @since 1.1
  */
-public final class UncheckedFunc<T, R, E extends Throwable> implements Function<T, R> {
+public final class UncheckedFunc<T, R, E extends Exception> implements Function<T, R> {
 
     /**
      * Checked version.
@@ -30,12 +30,12 @@ public final class UncheckedFunc<T, R, E extends Throwable> implements Function<
     }
 
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingThrowable")
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public R apply(final T val) {
         try {
             return this.checked.apply(val);
             // @checkstyle IllegalCatchCheck (1 line)
-        } catch (final Throwable err) {
+        } catch (final Exception err) {
             throw new ArtipieException(err);
         }
     }
@@ -48,7 +48,7 @@ public final class UncheckedFunc<T, R, E extends Throwable> implements Function<
      * @since 1.1
      */
     @FunctionalInterface
-    public interface Checked<T, R, E extends Throwable> {
+    public interface Checked<T, R, E extends Exception> {
 
         /**
          * Apply value.

--- a/src/main/java/com/artipie/asto/misc/UncheckedIOConsumer.java
+++ b/src/main/java/com/artipie/asto/misc/UncheckedIOConsumer.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.misc;
+
+import com.artipie.asto.ArtipieIOException;
+import java.io.IOException;
+import java.util.function.Consumer;
+
+/**
+ * Unchecked IO {@link Consumer}.
+ * @param <T> Consumer type
+ * @since 1.1
+ * @checkstyle AbbreviationAsWordInNameCheck (200 lines)
+ */
+public final class UncheckedIOConsumer<T> implements Consumer<T> {
+
+    /**
+     * Checked version.
+     */
+    private final UncheckedConsumer.Checked<T, IOException> checked;
+
+    /**
+     * Ctor.
+     * @param checked Checked func
+     */
+    public UncheckedIOConsumer(final UncheckedConsumer.Checked<T, IOException> checked) {
+        this.checked = checked;
+    }
+
+    @Override
+    public void accept(final T val) {
+        try {
+            this.checked.accept(val);
+        } catch (final IOException err) {
+            throw new ArtipieIOException(err);
+        }
+    }
+}

--- a/src/main/java/com/artipie/asto/misc/UncheckedIOConsumer.java
+++ b/src/main/java/com/artipie/asto/misc/UncheckedIOConsumer.java
@@ -19,13 +19,13 @@ public final class UncheckedIOConsumer<T> implements Consumer<T> {
     /**
      * Checked version.
      */
-    private final UncheckedConsumer.Checked<T, IOException> checked;
+    private final UncheckedConsumer.Checked<T, ? extends IOException> checked;
 
     /**
      * Ctor.
      * @param checked Checked func
      */
-    public UncheckedIOConsumer(final UncheckedConsumer.Checked<T, IOException> checked) {
+    public UncheckedIOConsumer(final UncheckedConsumer.Checked<T, ? extends IOException> checked) {
         this.checked = checked;
     }
 

--- a/src/main/java/com/artipie/asto/misc/UncheckedIOFunc.java
+++ b/src/main/java/com/artipie/asto/misc/UncheckedIOFunc.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.misc;
+
+import com.artipie.asto.ArtipieIOException;
+import java.io.IOException;
+import java.util.function.Function;
+
+/**
+ * Unchecked IO {@link Function}.
+ * @param <T> Function type
+ * @param <R> Function return type
+ * @since 1.1
+ * @checkstyle AbbreviationAsWordInNameCheck (200 lines)
+ */
+public final class UncheckedIOFunc<T, R> implements Function<T, R> {
+
+    /**
+     * Checked version.
+     */
+    private final UncheckedFunc.Checked<T, R, IOException> checked;
+
+    /**
+     * Ctor.
+     * @param checked Checked func
+     */
+    public UncheckedIOFunc(final UncheckedFunc.Checked<T, R, IOException> checked) {
+        this.checked = checked;
+    }
+
+    @Override
+    public R apply(final T val) {
+        try {
+            return this.checked.apply(val);
+        } catch (final IOException err) {
+            throw new ArtipieIOException(err);
+        }
+    }
+}

--- a/src/main/java/com/artipie/asto/misc/UncheckedIOFunc.java
+++ b/src/main/java/com/artipie/asto/misc/UncheckedIOFunc.java
@@ -20,13 +20,13 @@ public final class UncheckedIOFunc<T, R> implements Function<T, R> {
     /**
      * Checked version.
      */
-    private final UncheckedFunc.Checked<T, R, IOException> checked;
+    private final UncheckedFunc.Checked<T, R, ? extends IOException> checked;
 
     /**
      * Ctor.
      * @param checked Checked func
      */
-    public UncheckedIOFunc(final UncheckedFunc.Checked<T, R, IOException> checked) {
+    public UncheckedIOFunc(final UncheckedFunc.Checked<T, R, ? extends IOException> checked) {
         this.checked = checked;
     }
 

--- a/src/main/java/com/artipie/asto/misc/package-info.java
+++ b/src/main/java/com/artipie/asto/misc/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+
+/**
+ * Misc tools.
+ *
+ * @since 1.2
+ */
+package com.artipie.asto.misc;

--- a/src/test/java/com/artipie/asto/misc/UncheckedConsumerTest.java
+++ b/src/test/java/com/artipie/asto/misc/UncheckedConsumerTest.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.misc;
+
+import com.artipie.ArtipieException;
+import com.artipie.asto.ArtipieIOException;
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link UncheckedConsumer} and {@link UncheckedIOConsumer}.
+ * @since 1.1
+ * @checkstyle LeftCurlyCheck (200 lines)
+ * @checkstyle AbbreviationAsWordInNameCheck (200 lines)
+ */
+class UncheckedConsumerTest {
+
+    @Test
+    void throwsArtipieException() {
+        final Exception error = new Exception("Error");
+        final Exception res = Assertions.assertThrows(
+            ArtipieException.class,
+            () -> new UncheckedConsumer<>(ignored -> { throw error; }).accept("ignored")
+        );
+        MatcherAssert.assertThat(
+            res.getCause(),
+            new IsEqual<>(error)
+        );
+    }
+
+    @Test
+    void throwsArtipieIOException() {
+        final IOException error = new IOException("IO error");
+        final Exception res = Assertions.assertThrows(
+            ArtipieIOException.class,
+            () -> new UncheckedIOConsumer<>(ignored -> { throw error; }).accept("nothing")
+        );
+        MatcherAssert.assertThat(
+            res.getCause(),
+            new IsEqual<>(error)
+        );
+    }
+
+}

--- a/src/test/java/com/artipie/asto/misc/UncheckedFuncTest.java
+++ b/src/test/java/com/artipie/asto/misc/UncheckedFuncTest.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.misc;
+
+import com.artipie.ArtipieException;
+import com.artipie.asto.ArtipieIOException;
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link UncheckedFunc} and {@link UncheckedIOFunc}.
+ * @since 1.1
+ * @checkstyle LeftCurlyCheck (200 lines)
+ * @checkstyle AbbreviationAsWordInNameCheck (200 lines)
+ */
+class UncheckedFuncTest {
+
+    @Test
+    void throwsArtipieException() {
+        final Exception error = new Exception("Error");
+        final Exception res = Assertions.assertThrows(
+            ArtipieException.class,
+            () -> new UncheckedFunc<>(ignored -> { throw error; }).apply("ignored")
+        );
+        MatcherAssert.assertThat(
+            res.getCause(),
+            new IsEqual<>(error)
+        );
+    }
+
+    @Test
+    void throwsArtipieIOException() {
+        final IOException error = new IOException("IO error");
+        final Exception res = Assertions.assertThrows(
+            ArtipieIOException.class,
+            () -> new UncheckedIOFunc<>(ignored -> { throw error; }).apply("nothing")
+        );
+        MatcherAssert.assertThat(
+            res.getCause(),
+            new IsEqual<>(error)
+        );
+    }
+
+}

--- a/src/test/java/com/artipie/asto/misc/package-info.java
+++ b/src/test/java/com/artipie/asto/misc/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+
+/**
+ * Misc tools tests.
+ *
+ * @since 1.1
+ */
+package com.artipie.asto.misc;


### PR DESCRIPTION
Closes #317 
Moved `UncheckedConsumer` and `UncheckedFunc` from rpm and corrected them to throw `ArtipieException`, also added specific `UncheckedIOConsumer` and `UncheckedIOFunc`  for IO errors.