### PR TITLE
Add implementation for `delete` and `exists`

### DIFF
--- a/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
+++ b/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
@@ -115,7 +115,7 @@ public final class BenchmarkStorage implements Storage {
                     res = notFoundCompletion(key);
                 } else {
                     if (this.deleted.contains(key)) {
-                        res = new FailedCompletionStage<>(new ValueNotFoundException(key));
+                        res = notFoundCompletion(key);
                     } else {
                         res = CompletableFuture.completedFuture(
                             new Content.OneTime(new Content.From(lcl))

--- a/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
+++ b/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
@@ -59,7 +59,9 @@ public final class BenchmarkStorage implements Storage {
 
     @Override
     public CompletableFuture<Boolean> exists(final Key key) {
-        throw new NotImplementedError("Not implemented yet");
+        return CompletableFuture.completedFuture(
+            this.anyStorageContains(key) && !this.deleted.contains(key)
+        );
     }
 
     @Override
@@ -104,13 +106,13 @@ public final class BenchmarkStorage implements Storage {
             res = new FailedCompletionStage<>(new ArtipieIOException("Unable to load from root"));
         } else {
             if (this.deleted.contains(key)) {
-                res = new FailedCompletionStage<>(new ValueNotFoundException(key));
+                res = notFoundCompletion(key);
             } else {
                 final byte[] lcl = this.local.computeIfAbsent(
                     key, ckey -> this.backend.data.get(ckey.string())
                 );
                 if (lcl == null) {
-                    res = new FailedCompletionStage<>(new ValueNotFoundException(key));
+                    res = notFoundCompletion(key);
                 } else {
                     if (this.deleted.contains(key)) {
                         res = new FailedCompletionStage<>(new ValueNotFoundException(key));
@@ -127,7 +129,18 @@ public final class BenchmarkStorage implements Storage {
 
     @Override
     public CompletableFuture<Void> delete(final Key key) {
-        throw new NotImplementedError("Not implemented yet");
+        final CompletionStage<Void> res;
+        synchronized (this.deleted) {
+            if (this.anyStorageContains(key) && !this.deleted.contains(key)) {
+                this.deleted.add(key);
+                res = CompletableFuture.allOf();
+            } else {
+                res = new FailedCompletionStage<>(
+                    new ArtipieIOException(String.format("Key does not exist: %s", key.string()))
+                );
+            }
+        }
+        return res.toCompletableFuture();
     }
 
     @Override
@@ -136,5 +149,24 @@ public final class BenchmarkStorage implements Storage {
         final Function<Storage, CompletionStage<T>> operation
     ) {
         throw new NotImplementedError("Not implemented yet");
+    }
+
+    /**
+     * Verify whether key exists in local or backend storage.
+     * @param key Key for check
+     * @return True if key exists in local or backend storage, false otherwise.
+     */
+    private boolean anyStorageContains(final Key key) {
+        return this.local.containsKey(key) || this.backend.data.containsKey(key.string());
+    }
+
+    /**
+     * Obtains failed completion for not found key.
+     * @param key Not found key
+     * @param <T> Ignore
+     * @return Failed completion for not found key.
+     */
+    private static <T> CompletionStage<T> notFoundCompletion(final Key key) {
+        return new FailedCompletionStage<>(new ValueNotFoundException(key));
     }
 }

--- a/src/test/java/com/artipie/asto/memory/BenchmarkStorageDeleteTest.java
+++ b/src/test/java/com/artipie/asto/memory/BenchmarkStorageDeleteTest.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.memory;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.ValueNotFoundException;
+import com.artipie.asto.ext.PublisherAs;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.concurrent.CompletionException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link BenchmarkStorage#delete(Key)}.
+ * @since 1.2.0
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+final class BenchmarkStorageDeleteTest {
+    @Test
+    void obtainsValueWhichWasAddedBySameKeyAfterDeletionToVerifyDeletedWasReset() {
+        final InMemoryStorage memory = new InMemoryStorage();
+        final BenchmarkStorage bench = new BenchmarkStorage(memory);
+        final Key key = new Key.From("somekey");
+        bench.save(key, new Content.From("old data".getBytes())).join();
+        bench.delete(key);
+        final byte[] upd = "updated data".getBytes();
+        bench.save(key, new Content.From(upd)).join();
+        MatcherAssert.assertThat(
+            new PublisherAs(bench.value(key).join())
+                .bytes()
+                .toCompletableFuture().join(),
+            new IsEqual<>(upd)
+        );
+    }
+
+    @Test
+    void returnsNotFoundIfValueWasDeletedButPresentInBackend() {
+        final Key key = new Key.From("somekey");
+        final NavigableMap<String, byte[]> backdata = new TreeMap<>();
+        backdata.put(key.string(), "shouldBeObtained".getBytes());
+        final InMemoryStorage memory = new InMemoryStorage(backdata);
+        final BenchmarkStorage bench = new BenchmarkStorage(memory);
+        bench.delete(key);
+        final Throwable thr = Assertions.assertThrows(
+            CompletionException.class,
+            () -> bench.value(key).join()
+        );
+        MatcherAssert.assertThat(
+            thr.getCause(),
+            new IsInstanceOf(ValueNotFoundException.class)
+        );
+    }
+}

--- a/src/test/java/com/artipie/asto/memory/BenchmarkStorageExistsTest.java
+++ b/src/test/java/com/artipie/asto/memory/BenchmarkStorageExistsTest.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.memory;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link BenchmarkStorage#exists(Key)} (Key)}.
+ * @since 1.2.0
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+final class BenchmarkStorageExistsTest {
+    @Test
+    void existsWhenPresentInLocalAndNotDeleted() {
+        final InMemoryStorage memory = new InMemoryStorage();
+        final BenchmarkStorage bench = new BenchmarkStorage(memory);
+        final Key key = new Key.From("somekey");
+        bench.save(key, Content.EMPTY).join();
+        MatcherAssert.assertThat(
+            bench.exists(key).join(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void existsWhenPresentInBackendAndNotDeleted() {
+        final Key key = new Key.From("somekey");
+        final NavigableMap<String, byte[]> backdata = new TreeMap<>();
+        backdata.put(key.string(), "shouldExist".getBytes());
+        final InMemoryStorage memory = new InMemoryStorage(backdata);
+        final BenchmarkStorage bench = new BenchmarkStorage(memory);
+        MatcherAssert.assertThat(
+            bench.exists(key).join(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void notExistsIfKeyWasDeleted() {
+        final InMemoryStorage memory = new InMemoryStorage();
+        final BenchmarkStorage bench = new BenchmarkStorage(memory);
+        final Key key = new Key.From("somekey");
+        bench.save(key, new Content.From("any data".getBytes())).join();
+        bench.delete(key);
+        MatcherAssert.assertThat(
+            bench.exists(key).join(),
+            new IsEqual<>(false)
+        );
+    }
+}


### PR DESCRIPTION
Part of #314
Added implementation of `delete` and  `exists` for benchmark storage and tests. 
For `delete` operation `synchronized` block was used because it is necessary firstly to check existence and after that add to set in case of absence