### PR TITLE
Add implementation for `list` and `size`, optimize `delete`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The main types here are:
 [Key](https://www.javadoc.io/doc/com.artipie/asto/latest/com/artipie/asto/Key.html) and other types are
 documented in [javadoc](https://www.javadoc.io/doc/com.artipie/asto/latest/index.html).
 
-TODO: add more details
+TO DO: add more details
 
 ## How to contribute
 

--- a/src/main/java/com/artipie/asto/Key.java
+++ b/src/main/java/com/artipie/asto/Key.java
@@ -23,7 +23,7 @@ public interface Key {
     /**
      * Comparator for key values by their string representation.
      */
-    Comparator<Key> CMPRTR_STRING = Comparator.comparing(Key::string);
+    Comparator<Key> CMP_STRING = Comparator.comparing(Key::string);
 
     /**
      * Root key.

--- a/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
+++ b/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
@@ -69,7 +69,7 @@ public final class BenchmarkStorage implements Storage {
      */
     public BenchmarkStorage(final InMemoryStorage backend) {
         this.backend = backend;
-        this.local = new ConcurrentSkipListMap<>(Key.CMPRTR_STRING);
+        this.local = new ConcurrentSkipListMap<>(Key.CMP_STRING);
         this.deleted = ConcurrentHashMap.newKeySet();
     }
 
@@ -85,7 +85,7 @@ public final class BenchmarkStorage implements Storage {
         return CompletableFuture.supplyAsync(
             () -> {
                 final String prefix = root.string();
-                final Collection<Key> keys = new TreeSet<>(Key.CMPRTR_STRING);
+                final Collection<Key> keys = new TreeSet<>(Key.CMP_STRING);
                 final SortedSet<String> bckndkeys = this.backend.data
                     .navigableKeySet()
                     .tailSet(prefix);

--- a/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
+++ b/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
@@ -17,8 +17,11 @@ import com.artipie.asto.ext.CompletableFutureSupport;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.vavr.NotImplementedError;
 import java.util.Collection;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.NavigableMap;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -26,7 +29,21 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Function;
 
 /**
- * Storage implementation for benchmarks.
+ * Storage implementation for benchmarks. It consists of two different storage:
+ * <b>backend</b> which should be {@link InMemoryStorage} and
+ * <b>local</b> storage which represents map collection.
+ * <p>
+ *     Value is obtained from backend storage in case of absence in local.
+ *     And after that this obtained value is stored in local storage.
+ * </p>
+ * <p>
+ *     Backend storage in this implementation should be used only for read
+ *     operations (e.g. readonly).
+ * </p>
+ * <p>
+ *     This class has set with deleted keys. If key exists in this collection,
+ *     this key is considered deleted. It allows to just emulate delete operation.
+ * </p>
  * @since 1.1.0
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
@@ -40,7 +57,7 @@ public final class BenchmarkStorage implements Storage {
     /**
      * Local storage.
      */
-    private final Map<Key, byte[]> local;
+    private final NavigableMap<Key, byte[]> local;
 
     /**
      * Set which contains deleted keys.
@@ -65,8 +82,38 @@ public final class BenchmarkStorage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Collection<Key>> list(final Key prefix) {
-        throw new NotImplementedError("Not implemented yet");
+    public CompletableFuture<Collection<Key>> list(final Key root) {
+        return CompletableFuture.supplyAsync(
+            () -> {
+                final String prefix = root.string();
+                final Collection<Key> keys = new TreeSet<>(Key.CMPRTR_STRING);
+                final SortedSet<String> bckndkeys = this.backend.data
+                    .navigableKeySet()
+                    .tailSet(prefix);
+                final SortedSet<Key> lclkeys = this.local
+                    .navigableKeySet()
+                    .tailSet(new Key.From(prefix));
+                final Set<Key> delcopy;
+                synchronized (this.deleted) {
+                    delcopy = new HashSet<>(this.deleted);
+                }
+                for (final String keystr : bckndkeys) {
+                    if (keystr.startsWith(prefix) && !delcopy.contains(new Key.From(keystr))) {
+                        keys.add(new Key.From(keystr));
+                    } else {
+                        break;
+                    }
+                }
+                for (final Key key : lclkeys) {
+                    if (key.string().startsWith(prefix) && !delcopy.contains(key)) {
+                        keys.add(key);
+                    } else {
+                        break;
+                    }
+                }
+                return keys;
+            }
+        );
     }
 
     @Override
@@ -95,7 +142,19 @@ public final class BenchmarkStorage implements Storage {
 
     @Override
     public CompletableFuture<Long> size(final Key key) {
-        throw new NotImplementedError("Not implemented yet");
+        final CompletionStage<Long> res;
+        if (this.deleted.contains(key) || !this.anyStorageContains(key)) {
+            res = notFoundCompletion(key);
+        } else {
+            if (this.local.containsKey(key)) {
+                res = CompletableFuture.completedFuture((long) this.local.get(key).length);
+            } else {
+                res = CompletableFuture.completedFuture(
+                    (long) this.backend.data.get(key.string()).length
+                );
+            }
+        }
+        return res.toCompletableFuture();
     }
 
     @Override
@@ -130,15 +189,20 @@ public final class BenchmarkStorage implements Storage {
     @Override
     public CompletableFuture<Void> delete(final Key key) {
         final CompletionStage<Void> res;
-        synchronized (this.deleted) {
-            if (this.anyStorageContains(key) && !this.deleted.contains(key)) {
-                this.deleted.add(key);
+        if (this.anyStorageContains(key)) {
+            final boolean added = this.deleted.add(key);
+            if (added) {
                 res = CompletableFuture.allOf();
             } else {
                 res = new FailedCompletionStage<>(
                     new ArtipieIOException(String.format("Key does not exist: %s", key.string()))
                 );
             }
+
+        } else {
+            res = new FailedCompletionStage<>(
+                new ArtipieIOException(String.format("Key does not exist: %s", key.string()))
+            );
         }
         return res.toCompletableFuture();
     }

--- a/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
+++ b/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
@@ -17,7 +17,6 @@ import com.artipie.asto.ext.CompletableFutureSupport;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.vavr.NotImplementedError;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.SortedSet;
@@ -93,19 +92,15 @@ public final class BenchmarkStorage implements Storage {
                 final SortedSet<Key> lclkeys = this.local
                     .navigableKeySet()
                     .tailSet(new Key.From(prefix));
-                final Set<Key> delcopy;
-                synchronized (this.deleted) {
-                    delcopy = new HashSet<>(this.deleted);
-                }
                 for (final String keystr : bckndkeys) {
-                    if (keystr.startsWith(prefix) && !delcopy.contains(new Key.From(keystr))) {
+                    if (keystr.startsWith(prefix) && !this.deleted.contains(new Key.From(keystr))) {
                         keys.add(new Key.From(keystr));
                     } else {
                         break;
                     }
                 }
                 for (final Key key : lclkeys) {
-                    if (key.string().startsWith(prefix) && !delcopy.contains(key)) {
+                    if (key.string().startsWith(prefix) && !this.deleted.contains(key)) {
                         keys.add(key);
                     } else {
                         break;

--- a/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
+++ b/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
@@ -198,7 +198,6 @@ public final class BenchmarkStorage implements Storage {
                     new ArtipieIOException(String.format("Key does not exist: %s", key.string()))
                 );
             }
-
         } else {
             res = new FailedCompletionStage<>(
                 new ArtipieIOException(String.format("Key does not exist: %s", key.string()))

--- a/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
+++ b/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
@@ -93,15 +93,19 @@ public final class BenchmarkStorage implements Storage {
                     .navigableKeySet()
                     .tailSet(new Key.From(prefix));
                 for (final String keystr : bckndkeys) {
-                    if (keystr.startsWith(prefix) && !this.deleted.contains(new Key.From(keystr))) {
-                        keys.add(new Key.From(keystr));
+                    if (keystr.startsWith(prefix)) {
+                        if (!this.deleted.contains(new Key.From(keystr))) {
+                            keys.add(new Key.From(keystr));
+                        }
                     } else {
                         break;
                     }
                 }
                 for (final Key key : lclkeys) {
-                    if (key.string().startsWith(prefix) && !this.deleted.contains(key)) {
-                        keys.add(key);
+                    if (key.string().startsWith(prefix)) {
+                        if (!this.deleted.contains(key)) {
+                            keys.add(key);
+                        }
                     } else {
                         break;
                     }

--- a/src/test/java/com/artipie/asto/KeyTest.java
+++ b/src/test/java/com/artipie/asto/KeyTest.java
@@ -89,7 +89,7 @@ final class KeyTest {
         final Key frst = new Key.From("1");
         final Key scnd = new Key.From("2");
         MatcherAssert.assertThat(
-            Key.CMPRTR_STRING.compare(frst, scnd),
+            Key.CMP_STRING.compare(frst, scnd),
             new IsEqual<>(-1)
         );
     }

--- a/src/test/java/com/artipie/asto/memory/BenchmarkStorageDeleteTest.java
+++ b/src/test/java/com/artipie/asto/memory/BenchmarkStorageDeleteTest.java
@@ -29,7 +29,7 @@ final class BenchmarkStorageDeleteTest {
         final BenchmarkStorage bench = new BenchmarkStorage(memory);
         final Key key = new Key.From("somekey");
         bench.save(key, new Content.From("old data".getBytes())).join();
-        bench.delete(key);
+        bench.delete(key).join();
         final byte[] upd = "updated data".getBytes();
         bench.save(key, new Content.From(upd)).join();
         MatcherAssert.assertThat(
@@ -47,7 +47,7 @@ final class BenchmarkStorageDeleteTest {
         backdata.put(key.string(), "shouldBeObtained".getBytes());
         final InMemoryStorage memory = new InMemoryStorage(backdata);
         final BenchmarkStorage bench = new BenchmarkStorage(memory);
-        bench.delete(key);
+        bench.delete(key).join();
         final Throwable thr = Assertions.assertThrows(
             CompletionException.class,
             () -> bench.value(key).join()

--- a/src/test/java/com/artipie/asto/memory/BenchmarkStorageExistsTest.java
+++ b/src/test/java/com/artipie/asto/memory/BenchmarkStorageExistsTest.java
@@ -13,7 +13,7 @@ import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for {@link BenchmarkStorage#exists(Key)} (Key)}.
+ * Tests for {@link BenchmarkStorage#exists(Key)}.
  * @since 1.2.0
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -49,7 +49,7 @@ final class BenchmarkStorageExistsTest {
         final BenchmarkStorage bench = new BenchmarkStorage(memory);
         final Key key = new Key.From("somekey");
         bench.save(key, new Content.From("any data".getBytes())).join();
-        bench.delete(key);
+        bench.delete(key).join();
         MatcherAssert.assertThat(
             bench.exists(key).join(),
             new IsEqual<>(false)

--- a/src/test/java/com/artipie/asto/memory/BenchmarkStorageListTest.java
+++ b/src/test/java/com/artipie/asto/memory/BenchmarkStorageListTest.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.memory;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import java.util.Collections;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link BenchmarkStorage#list(Key)} (Key)}.
+ * @since 1.2.0
+ */
+final class BenchmarkStorageListTest {
+    @Test
+    void returnsListWhenPresentInLocalAndNotDeleted() {
+        final InMemoryStorage memory = new InMemoryStorage();
+        final BenchmarkStorage bench = new BenchmarkStorage(memory);
+        final Key key = new Key.From("someLocalkey");
+        bench.save(key, Content.EMPTY).join();
+        MatcherAssert.assertThat(
+            bench.list(key).join(),
+            new IsEqual<>(Collections.singleton(key))
+        );
+    }
+
+    @Test
+    void returnsSizeWhenPresentInBackendAndNotDeleted() {
+        final Key key = new Key.From("someBackendkey");
+        final NavigableMap<String, byte[]> backdata = new TreeMap<>();
+        backdata.put(key.string(), "".getBytes());
+        final InMemoryStorage memory = new InMemoryStorage(backdata);
+        final BenchmarkStorage bench = new BenchmarkStorage(memory);
+        MatcherAssert.assertThat(
+            bench.list(key).join(),
+            new IsEqual<>(Collections.singleton(key))
+        );
+    }
+
+    @Test
+    void combineKeysFromLocalAndBackendStorages() {
+        final Key prfx = new Key.From("prefix");
+        final Key bcknd = new Key.From(prfx, "backendkey");
+        final NavigableMap<String, byte[]> backdata = new TreeMap<>();
+        backdata.put(bcknd.string(), "".getBytes());
+        final InMemoryStorage memory = new InMemoryStorage(backdata);
+        final BenchmarkStorage bench = new BenchmarkStorage(memory);
+        final Key lcl = new Key.From(prfx, "localkey");
+        bench.save(lcl, Content.EMPTY).join();
+        MatcherAssert.assertThat(
+            bench.list(prfx).join(),
+            Matchers.containsInAnyOrder(bcknd, lcl)
+        );
+    }
+
+    @Test
+    void notConsiderDeletedKey() {
+        final Key delkey = new Key.From("willBeDeleted");
+        final Key existkey = new Key.From("shouldRemain");
+        final NavigableMap<String, byte[]> backdata = new TreeMap<>();
+        backdata.put(delkey.string(), "will be deleted".getBytes());
+        backdata.put(existkey.string(), "should remain".getBytes());
+        final InMemoryStorage memory = new InMemoryStorage(backdata);
+        final BenchmarkStorage bench = new BenchmarkStorage(memory);
+        bench.delete(delkey);
+        MatcherAssert.assertThat(
+            bench.list(Key.ROOT).join(),
+            new IsEqual<>(Collections.singleton(existkey))
+        );
+    }
+}

--- a/src/test/java/com/artipie/asto/memory/BenchmarkStorageListTest.java
+++ b/src/test/java/com/artipie/asto/memory/BenchmarkStorageListTest.java
@@ -15,7 +15,7 @@ import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for {@link BenchmarkStorage#list(Key)} (Key)}.
+ * Tests for {@link BenchmarkStorage#list(Key)}.
  * @since 1.2.0
  */
 final class BenchmarkStorageListTest {
@@ -69,7 +69,7 @@ final class BenchmarkStorageListTest {
         backdata.put(existkey.string(), "should remain".getBytes());
         final InMemoryStorage memory = new InMemoryStorage(backdata);
         final BenchmarkStorage bench = new BenchmarkStorage(memory);
-        bench.delete(delkey);
+        bench.delete(delkey).join();
         MatcherAssert.assertThat(
             bench.list(Key.ROOT).join(),
             new IsEqual<>(Collections.singleton(existkey))

--- a/src/test/java/com/artipie/asto/memory/BenchmarkStorageSizeTest.java
+++ b/src/test/java/com/artipie/asto/memory/BenchmarkStorageSizeTest.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.memory;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.ValueNotFoundException;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.concurrent.CompletionException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link BenchmarkStorage#size(Key)} (Key)}.
+ * @since 1.2.0
+ */
+final class BenchmarkStorageSizeTest {
+    @Test
+    void returnsSizeWhenPresentInLocalAndNotDeleted() {
+        final byte[] data = "example data".getBytes();
+        final InMemoryStorage memory = new InMemoryStorage();
+        final BenchmarkStorage bench = new BenchmarkStorage(memory);
+        final Key key = new Key.From("someLocalKey");
+        bench.save(key, new Content.From(data)).join();
+        MatcherAssert.assertThat(
+            bench.size(key).join(),
+            new IsEqual<>((long) data.length)
+        );
+    }
+
+    @Test
+    void returnsSizeWhenPresentInBackendAndNotDeleted() {
+        final byte[] data = "super data".getBytes();
+        final Key key = new Key.From("someBackendKey");
+        final NavigableMap<String, byte[]> backdata = new TreeMap<>();
+        backdata.put(key.string(), data);
+        final InMemoryStorage memory = new InMemoryStorage(backdata);
+        final BenchmarkStorage bench = new BenchmarkStorage(memory);
+        MatcherAssert.assertThat(
+            bench.size(key).join(),
+            new IsEqual<>((long) data.length)
+        );
+    }
+
+    @Test
+    void throwsIfKeyWasDeleted() {
+        final InMemoryStorage memory = new InMemoryStorage();
+        final BenchmarkStorage bench = new BenchmarkStorage(memory);
+        final Key key = new Key.From("somekey");
+        bench.save(key, new Content.From("will be deleted".getBytes())).join();
+        bench.delete(key);
+        final Throwable thr = Assertions.assertThrows(
+            CompletionException.class,
+            () -> bench.size(key).join()
+        );
+        MatcherAssert.assertThat(
+            thr.getCause(),
+            new IsInstanceOf(ValueNotFoundException.class)
+        );
+    }
+}

--- a/src/test/java/com/artipie/asto/memory/BenchmarkStorageSizeTest.java
+++ b/src/test/java/com/artipie/asto/memory/BenchmarkStorageSizeTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for {@link BenchmarkStorage#size(Key)} (Key)}.
+ * Tests for {@link BenchmarkStorage#size(Key)}.
  * @since 1.2.0
  */
 final class BenchmarkStorageSizeTest {
@@ -54,7 +54,7 @@ final class BenchmarkStorageSizeTest {
         final BenchmarkStorage bench = new BenchmarkStorage(memory);
         final Key key = new Key.From("somekey");
         bench.save(key, new Content.From("will be deleted".getBytes())).join();
-        bench.delete(key);
+        bench.delete(key).join();
         final Throwable thr = Assertions.assertThrows(
             CompletionException.class,
             () -> bench.size(key).join()


### PR DESCRIPTION
Part of #314
Added implementation of `list` and `size` for benchmark storage and tests.
Optimize `delete` by avoid using synchronize block because the result of `add` operation could be used instead