### PR TITLE
Exclude `com.google.android:annotations` from etcd dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,12 @@ SOFTWARE.
       <groupId>io.etcd</groupId>
       <artifactId>jetcd-core</artifactId>
       <version>0.5.4</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.android</groupId>
+          <artifactId>annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.etcd</groupId>


### PR DESCRIPTION
Part of #325 