### PR TITLE
Exclude fasterxml jackson databind from `vertx-rx-java2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.2
+
+ - dep: exclude fasterxml jackson databind from vertx-rx-java2
+
 # 1.3.1
 
  - dep: exclude android annotations from etcd

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,12 @@ SOFTWARE.
       <groupId>io.vertx</groupId>
       <artifactId>vertx-rx-java2</artifactId>
       <version>${vertx.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>


### PR DESCRIPTION
Part of #325 