### PR TITLE
Make method `StorageValuePipeline.process()` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.5.1
+
+ - fix: Make method `StorageValuePipeline.process()` public (#333)
+
 # v1.5.0
 
  - feat: Added class to process asto value as input/output streams (#334)

--- a/src/main/java/com/artipie/asto/streams/StorageValuePipeline.java
+++ b/src/main/java/com/artipie/asto/streams/StorageValuePipeline.java
@@ -57,7 +57,9 @@ public final class StorageValuePipeline {
      * @return Completion action
      * @throws ArtipieIOException On Error
      */
-    CompletionStage<Void> process(final BiConsumer<Optional<InputStream>, OutputStream> action) {
+    public CompletionStage<Void> process(
+        final BiConsumer<Optional<InputStream>, OutputStream> action
+    ) {
         return this.asto.exists(this.key).thenCompose(
             exists -> {
                 final CompletionStage<Void> future;


### PR DESCRIPTION
Part of #333 
Fixed method `StorageValuePipeline.process()` to be public