### PR TITLE
feat: test resource save to file

### DIFF
--- a/src/main/java/com/artipie/asto/test/TestResource.java
+++ b/src/main/java/com/artipie/asto/test/TestResource.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
@@ -51,6 +52,15 @@ public final class TestResource {
      */
     public void saveTo(final Storage storage) {
         this.saveTo(storage, new Key.From(this.name));
+    }
+
+    /**
+     * Save test resource to path.
+     * @param path Where to save
+     * @throws IOException On IO error
+     */
+    public void saveTo(final Path path) throws IOException {
+        Files.write(path, this.asBytes());
     }
 
     /**

--- a/src/test/java/com/artipie/asto/test/TestResourceTest.java
+++ b/src/test/java/com/artipie/asto/test/TestResourceTest.java
@@ -8,11 +8,15 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.ext.PublisherAs;
 import com.artipie.asto.memory.InMemoryStorage;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test for {@link TestResource}.
@@ -46,6 +50,16 @@ class TestResourceTest {
             new PublisherAs(storage.value(new Key.From(path)).join())
                 .bytes().toCompletableFuture().join(),
             new IsEqual<>("hello world".getBytes())
+        );
+    }
+
+    @Test
+    void saveToPath(@TempDir final Path tmp) throws Exception {
+        final Path target = tmp.resolve("target");
+        new TestResource("test.txt").saveTo(target);
+        MatcherAssert.assertThat(
+            Files.readAllLines(target),
+            Matchers.contains("hello world")
         );
     }
 


### PR DESCRIPTION
Added method for `TestResource` to save it directly to
file (`Path`).

Ticket: #218
Related: artipie/gem-adapter#130