### PR TITLE
feat(metadata): storage metadata API

### DIFF
--- a/src/main/java/com/artipie/asto/LoggingStorage.java
+++ b/src/main/java/com/artipie/asto/LoggingStorage.java
@@ -88,7 +88,9 @@ public final class LoggingStorage implements Storage {
         );
     }
 
+    // @checkstyle MissingDeprecatedCheck (5 lines)
     @Override
+    @Deprecated
     public CompletableFuture<Long> size(final Key key) {
         return this.storage.size(key).thenApply(
             result -> {
@@ -126,6 +128,16 @@ public final class LoggingStorage implements Storage {
         return this.storage.exclusively(key, operation).thenApply(
             result -> {
                 this.log("Exclusively for '%s': %s", key, operation);
+                return result;
+            }
+        );
+    }
+
+    @Override
+    public CompletableFuture<? extends Meta> metadata(final Key key) {
+        return this.storage.metadata(key).thenApply(
+            result -> {
+                this.log("Metadata '%s': %s", key.string(), result);
                 return result;
             }
         );

--- a/src/main/java/com/artipie/asto/Meta.java
+++ b/src/main/java/com/artipie/asto/Meta.java
@@ -1,0 +1,155 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Storage content metadata.
+ * @since 1.9
+ */
+public interface Meta {
+
+    /**
+     * Operator for MD5 hash.
+     */
+    OpRWSimple<String> OP_MD5 = new OpRWSimple<>("md5", Function.identity());
+
+    /**
+     * Operator for size.
+     */
+    OpRWSimple<Long> OP_SIZE = new OpRWSimple<>("size", Long::parseLong);
+
+    /**
+     * Operator for created time.
+     */
+    OpRWSimple<Instant> OP_CREATED_AT = new OpRWSimple<>("created-at", Instant::parse);
+
+    /**
+     * Operator for updated time.
+     */
+    OpRWSimple<Instant> OP_UPDATED_AT = new OpRWSimple<>("updated-at", Instant::parse);
+
+    /**
+     * Operator for last access time.
+     */
+    OpRWSimple<Instant> OP_ACCESSED_AT = new OpRWSimple<>("accessed-at", Instant::parse);
+
+    /**
+     * Empty metadata.
+     */
+    Meta EMPTY = new Meta() {
+        @Override
+        public <T> T read(final Meta.ReadOperator<T> opr) {
+            return opr.take(Collections.emptyMap());
+        }
+    };
+
+    /**
+     * Read metadata.
+     * @param opr Operator to read
+     * @param <T> Value type
+     * @return Metadata value
+     */
+    <T> T read(Meta.ReadOperator<T> opr);
+
+    /**
+     * Metadata read operator.
+     * @param <T> Result type
+     * @since 1.0
+     */
+    @FunctionalInterface
+    interface ReadOperator<T> {
+
+        /**
+         * Take metadata param from raw metadata.
+         * @param raw Readonly map of strings
+         * @return Metadata value
+         */
+        T take(Map<String, ? extends String> raw);
+    }
+
+    /**
+     * Metadata write operator.
+     * @param <T> Value type
+     * @since 1.9
+     */
+    @FunctionalInterface
+    interface WriteOperator<T> {
+
+        /**
+         * Put value to raw metadata.
+         * @param raw Raw metadata map
+         * @param val Value
+         */
+        void put(Map<String, String> raw, T val);
+    }
+
+    /**
+     * Read and write simple operator implementation.
+     * @param <T> Value type
+     * @since 1.9
+     * @checkstyle AbbreviationAsWordInNameCheck (5 lines)
+     */
+    final class OpRWSimple<T> implements ReadOperator<Optional<? extends T>>, WriteOperator<T> {
+
+        /**
+         * Raw data key.
+         */
+        private final String key;
+
+        /**
+         * Parser function.
+         */
+        private final Function<? super String, ? extends T> parser;
+
+        /**
+         * Serializer func.
+         */
+        private final Function<? super T, ? extends String> serializer;
+
+        /**
+         * New operator with default {@link Object#toString()} serializer.
+         * @param key Data key
+         * @param parser Parser function
+         */
+        public OpRWSimple(final String key, final Function<? super String, ? extends T> parser) {
+            this(key, parser, Object::toString);
+        }
+
+        /**
+         * New operator.
+         * @param key Data key
+         * @param parser Parser function
+         * @param serializer Serializer
+         */
+        public OpRWSimple(final String key, final Function<? super String, ? extends T> parser,
+            final Function<? super T, ? extends String> serializer) {
+            this.key = key;
+            this.parser = parser;
+            this.serializer = serializer;
+        }
+
+        @Override
+        public void put(final Map<String, String> raw, final T val) {
+            raw.put(this.key, this.serializer.apply(val));
+        }
+
+        @Override
+        public Optional<? extends T> take(final Map<String, ? extends String> raw) {
+            final Optional<? extends T> result;
+            if (raw.containsKey(this.key)) {
+                result = Optional.of(raw.get(this.key)).map(this.parser);
+            } else {
+                result = Optional.empty();
+            }
+            return result;
+        }
+    }
+}

--- a/src/main/java/com/artipie/asto/Storage.java
+++ b/src/main/java/com/artipie/asto/Storage.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.asto;
 
+import com.artipie.ArtipieException;
 import com.artipie.asto.fs.FileStorage;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -62,8 +63,25 @@ public interface Storage {
      *
      * @param key The key of value.
      * @return Size of value in bytes.
+     * @deprecated Use {@link #metadata(Key)} to get content size
      */
-    CompletableFuture<Long> size(Key key);
+    @Deprecated
+    default CompletableFuture<Long> size(final Key key) {
+        return this.metadata(key).thenApply(
+            meta -> meta.read(Meta.OP_SIZE).orElseThrow(
+                () -> new ArtipieException(
+                    String.format("SIZE could't be read for %s key", key.string())
+                )
+            )
+        );
+    }
+
+    /**
+     * Get content metadata.
+     * @param key Content key
+     * @return Future with metadata
+     */
+    CompletableFuture<? extends Meta> metadata(Key key);
 
     /**
      * Obtain bytes by key.

--- a/src/main/java/com/artipie/asto/SubStorage.java
+++ b/src/main/java/com/artipie/asto/SubStorage.java
@@ -82,9 +82,16 @@ public final class SubStorage implements Storage {
         );
     }
 
+    // @checkstyle MissingDeprecatedCheck (5 lines)
     @Override
+    @Deprecated
     public CompletableFuture<Long> size(final Key key) {
         return this.origin.size(new PrefixedKed(this.prefix, key));
+    }
+
+    @Override
+    public CompletableFuture<? extends Meta> metadata(final Key key) {
+        return this.origin.metadata(new PrefixedKed(this.prefix, key));
     }
 
     @Override

--- a/src/main/java/com/artipie/asto/blocking/BlockingStorage.java
+++ b/src/main/java/com/artipie/asto/blocking/BlockingStorage.java
@@ -78,7 +78,9 @@ public class BlockingStorage {
      *
      * @param key The key of value.
      * @return Size of value in bytes.
+     * @deprecated Storage size is deprecated
      */
+    @Deprecated
     public long size(final Key key) {
         return this.storage.size(key).join();
     }

--- a/src/main/java/com/artipie/asto/etcd/EtcdStorage.java
+++ b/src/main/java/com/artipie/asto/etcd/EtcdStorage.java
@@ -8,6 +8,7 @@ package com.artipie.asto.etcd;
 import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
+import com.artipie.asto.Meta;
 import com.artipie.asto.Storage;
 import com.artipie.asto.ValueNotFoundException;
 import com.artipie.asto.ext.CompletableFutureSupport;
@@ -106,16 +107,8 @@ public final class EtcdStorage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Long> size(final Key key) {
-        return this.client.getKVClient().get(keyToSeq(key)).thenApply(
-            rsp -> rsp.getKvs().stream().max(
-                (left, right) -> Long.compare(left.getVersion(), right.getVersion())
-            )
-        ).thenApply(
-            kv -> kv.orElseThrow(
-                () -> new ValueNotFoundException(key)
-            ).getValue().getBytes()
-        ).thenApply(bytes -> Long.valueOf(bytes.length));
+    public CompletableFuture<? extends Meta> metadata(final Key key) {
+        return CompletableFuture.completedFuture(Meta.EMPTY);
     }
 
     @Override

--- a/src/main/java/com/artipie/asto/fs/FileMeta.java
+++ b/src/main/java/com/artipie/asto/fs/FileMeta.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.fs;
+
+import com.artipie.asto.Meta;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Metadata for file.
+ * @since 1.9
+ */
+final class FileMeta implements Meta {
+
+    /**
+     * File attributes.
+     */
+    private final BasicFileAttributes attr;
+
+    /**
+     * New metadata.
+     * @param attr File attributes
+     */
+    FileMeta(final BasicFileAttributes attr) {
+        this.attr = attr;
+    }
+
+    @Override
+    public <T> T read(final ReadOperator<T> opr) {
+        final Map<String, String> raw = new HashMap<>();
+        Meta.OP_SIZE.put(raw, this.attr.size());
+        Meta.OP_ACCESSED_AT.put(raw, this.attr.lastAccessTime().toInstant());
+        Meta.OP_CREATED_AT.put(raw, this.attr.creationTime().toInstant());
+        Meta.OP_UPDATED_AT.put(raw, this.attr.lastModifiedTime().toInstant());
+        return opr.take(raw);
+    }
+}

--- a/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
+++ b/src/main/java/com/artipie/asto/memory/BenchmarkStorage.java
@@ -9,6 +9,7 @@ import com.artipie.asto.Concatenation;
 import com.artipie.asto.Content;
 import com.artipie.asto.FailedCompletionStage;
 import com.artipie.asto.Key;
+import com.artipie.asto.Meta;
 import com.artipie.asto.OneTimePublisher;
 import com.artipie.asto.Remaining;
 import com.artipie.asto.Storage;
@@ -157,7 +158,9 @@ public final class BenchmarkStorage implements Storage {
         return res.toCompletableFuture();
     }
 
+    // @checkstyle MissingDeprecatedCheck (5 lines)
     @Override
+    @Deprecated
     public CompletableFuture<Long> size(final Key key) {
         final CompletionStage<Long> res;
         if (this.deleted.contains(key) || !this.anyStorageContains(key)) {
@@ -170,6 +173,19 @@ public final class BenchmarkStorage implements Storage {
                     (long) this.backend.data.get(key.string()).length
                 );
             }
+        }
+        return res.toCompletableFuture();
+    }
+
+    @Override
+    public CompletableFuture<? extends Meta> metadata(final Key key) {
+        final CompletableFuture<Meta> res;
+        if (this.deleted.contains(key) || !this.anyStorageContains(key)) {
+            res = new FailedCompletionStage<Meta>(new ValueNotFoundException(key))
+                .toCompletableFuture();
+        } else {
+            res = new CompletableFuture<>();
+            res.complete(Meta.EMPTY);
         }
         return res.toCompletableFuture();
     }

--- a/src/main/java/com/artipie/asto/rx/RxStorageWrapper.java
+++ b/src/main/java/com/artipie/asto/rx/RxStorageWrapper.java
@@ -59,7 +59,9 @@ public final class RxStorageWrapper implements RxStorage {
         );
     }
 
+    // @checkstyle MissingDeprecatedCheck (5 lines)
     @Override
+    @Deprecated
     public Single<Long> size(final Key key) {
         return Single.defer(() -> SingleInterop.fromFuture(this.storage.size(key)));
     }

--- a/src/main/java/com/artipie/asto/s3/S3HeadMeta.java
+++ b/src/main/java/com/artipie/asto/s3/S3HeadMeta.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.s3;
+
+import com.artipie.asto.Meta;
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+
+/**
+ * Metadata from S3 object.
+ * @since 1.9
+ */
+final class S3HeadMeta implements Meta {
+
+    /**
+     * S3 head object response.
+     */
+    private final HeadObjectResponse rsp;
+
+    /**
+     * New metadata.
+     * @param rsp Head response
+     */
+    S3HeadMeta(final HeadObjectResponse rsp) {
+        this.rsp = rsp;
+    }
+
+    @Override
+    public <T> T read(final ReadOperator<T> opr) {
+        final Map<String, String> raw = new HashMap<>();
+        Meta.OP_SIZE.put(raw, this.rsp.contentLength());
+        // @checkstyle MethodBodyCommentsCheck (1 line)
+        // ETag is a quoted MD5 of blob content according to S3 docs
+        Meta.OP_MD5.put(raw, this.rsp.eTag().replaceAll("\"", ""));
+        return opr.take(raw);
+    }
+}

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -97,6 +97,7 @@ final class FileStorageTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void readsTheSize() throws Exception {
         final BlockingStorage bsto = new BlockingStorage(this.storage);
         final Key key = new Key.From("withSize");

--- a/src/test/java/com/artipie/asto/LoggingStorageTest.java
+++ b/src/test/java/com/artipie/asto/LoggingStorageTest.java
@@ -46,7 +46,9 @@ final class LoggingStorageTest {
         );
     }
 
+    // @checkstyle MissingDeprecatedCheck (5 lines)
     @Test
+    @Deprecated
     void readsTheSize() {
         final Key key = new Key.From("withSize");
         this.memsto.save(

--- a/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
+++ b/src/test/java/com/artipie/asto/StorageSaveAndLoadTest.java
@@ -163,6 +163,7 @@ public final class StorageSaveAndLoadTest {
             value::join
         );
         MatcherAssert.assertThat(
+            String.format("storage '%s' should fail", storage.getClass().getName()),
             exception.getCause(),
             new IsInstanceOf(ValueNotFoundException.class)
         );

--- a/src/test/java/com/artipie/asto/StorageSizeTest.java
+++ b/src/test/java/com/artipie/asto/StorageSizeTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since 0.17
  */
+@SuppressWarnings("deprecation")
 @ExtendWith(StorageExtension.class)
 public final class StorageSizeTest {
 
@@ -41,6 +42,7 @@ public final class StorageSizeTest {
             size::join
         );
         MatcherAssert.assertThat(
+            String.format("storage '%s' should fail", storage.getClass().getSimpleName()),
             exception.getCause(),
             new IsInstanceOf(ValueNotFoundException.class)
         );

--- a/src/test/java/com/artipie/asto/etcd/EtcdStorageITCase.java
+++ b/src/test/java/com/artipie/asto/etcd/EtcdStorageITCase.java
@@ -65,6 +65,7 @@ public final class EtcdStorageITCase {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void getSize() {
         final Key key = new Key.From("another", "key");
         final byte[] data = "data with size".getBytes();

--- a/src/test/java/com/artipie/asto/fs/FileMetaTest.java
+++ b/src/test/java/com/artipie/asto/fs/FileMetaTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.fs;
+
+import com.artipie.asto.Meta;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test case for {@link FileMeta}.
+ * @since 1.9
+ */
+final class FileMetaTest {
+
+    @Test
+    void readAttrs() {
+        final long len = 4;
+        final Instant creation = Instant.ofEpochMilli(1);
+        final Instant modified = Instant.ofEpochMilli(2);
+        final Instant access = Instant.ofEpochMilli(3);
+        final BasicFileAttributes attrs = Mockito.mock(BasicFileAttributes.class);
+        Mockito.when(attrs.size()).thenReturn(len);
+        Mockito.when(attrs.creationTime()).thenReturn(FileTime.from(creation));
+        Mockito.when(attrs.lastModifiedTime()).thenReturn(FileTime.from(modified));
+        Mockito.when(attrs.lastAccessTime()).thenReturn(FileTime.from(access));
+        MatcherAssert.assertThat(
+            "size",
+            new FileMeta(attrs).read(Meta.OP_SIZE).get(),
+            new IsEqual<>(len)
+        );
+        MatcherAssert.assertThat(
+            "created at",
+            new FileMeta(attrs).read(Meta.OP_CREATED_AT).get(),
+            new IsEqual<>(creation)
+        );
+        MatcherAssert.assertThat(
+            "updated at",
+            new FileMeta(attrs).read(Meta.OP_UPDATED_AT).get(),
+            new IsEqual<>(modified)
+        );
+        MatcherAssert.assertThat(
+            "accessed at",
+            new FileMeta(attrs).read(Meta.OP_ACCESSED_AT).get(),
+            new IsEqual<>(access)
+        );
+    }
+}

--- a/src/test/java/com/artipie/asto/fs/package-info.java
+++ b/src/test/java/com/artipie/asto/fs/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+
+/**
+ * Tests for FS objects.
+ *
+ * @since 1.9
+ */
+package com.artipie.asto.fs;
+

--- a/src/test/java/com/artipie/asto/lock/storage/StorageLockTest.java
+++ b/src/test/java/com/artipie/asto/lock/storage/StorageLockTest.java
@@ -7,6 +7,7 @@ package com.artipie.asto.lock.storage;
 import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
+import com.artipie.asto.Meta;
 import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
@@ -224,8 +225,14 @@ final class StorageLockTest {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public CompletableFuture<Long> size(final Key key) {
             return this.storage.size(key);
+        }
+
+        @Override
+        public CompletableFuture<? extends Meta> metadata(final Key key) {
+            return this.storage.metadata(key);
         }
 
         @Override

--- a/src/test/java/com/artipie/asto/memory/BenchmarkStorageSizeTest.java
+++ b/src/test/java/com/artipie/asto/memory/BenchmarkStorageSizeTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
  * Tests for {@link BenchmarkStorage#size(Key)}.
  * @since 1.2.0
  */
+@SuppressWarnings("deprecation")
 final class BenchmarkStorageSizeTest {
     @Test
     void returnsSizeWhenPresentInLocalAndNotDeleted() {

--- a/src/test/java/com/artipie/asto/s3/S3HeadMetaTest.java
+++ b/src/test/java/com/artipie/asto/s3/S3HeadMetaTest.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.s3;
+
+import com.artipie.asto.Meta;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+
+/**
+ * Test case for {@link S3HeadMeta}.
+ * @since 1.9
+ */
+final class S3HeadMetaTest {
+
+    @Test
+    void readSize() {
+        final long len = 1024;
+        MatcherAssert.assertThat(
+            new S3HeadMeta(
+                HeadObjectResponse.builder()
+                    .contentLength(len)
+                    .eTag("empty")
+                    .build()
+            ).read(Meta.OP_SIZE).get(),
+            new IsEqual<>(len)
+        );
+    }
+
+    @Test
+    void readHash() {
+        final String hash = "abc";
+        MatcherAssert.assertThat(
+            new S3HeadMeta(
+                HeadObjectResponse.builder()
+                    .contentLength(0L)
+                    .eTag(hash)
+                    .build()
+            ).read(Meta.OP_MD5).get(),
+            new IsEqual<>(hash)
+        );
+    }
+}

--- a/src/test/java/com/artipie/asto/s3/S3StorageTest.java
+++ b/src/test/java/com/artipie/asto/s3/S3StorageTest.java
@@ -12,6 +12,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
+import com.artipie.asto.Meta;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.google.common.io.ByteStreams;
 import io.reactivex.Flowable;
@@ -46,7 +47,6 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
  */
 @SuppressWarnings("PMD.TooManyMethods")
 class S3StorageTest {
-
     /**
      * Mock S3 server.
      */
@@ -216,6 +216,26 @@ class S3StorageTest {
         MatcherAssert.assertThat(
             client.doesObjectExist(this.bucket, key),
             new IsEqual<>(false)
+        );
+    }
+
+    @Test
+    void readMetadata(final AmazonS3 client) throws Exception {
+        final String key = "random/data";
+        client.putObject(
+            this.bucket, key,
+            new ByteArrayInputStream("random data".getBytes()), new ObjectMetadata()
+        );
+        final Meta meta = this.storage().metadata(new Key.From(key)).join();
+        MatcherAssert.assertThat(
+            "size",
+            meta.read(Meta.OP_SIZE).get(),
+            new IsEqual<>(11L)
+        );
+        MatcherAssert.assertThat(
+            "MD5",
+            meta.read(Meta.OP_MD5).get(),
+            new IsEqual<>("3e58b24739a19c3e2e1b21bac818c6cd")
         );
     }
 


### PR DESCRIPTION
Added `Meta` interface to represent blob metadata,
updated storage with new method `metadata(Key)`,
deprecated `size(Key)` method since it's covered by metadata method.
Added interfaces `Meta.ReadOperator<T>` and `Meta.WriteOperator<T>`
to serialize and parse data values to intermediate `Map<String, String>`
container. Updated all `Storage`s implementation and related tests.

**Reasons behind this implementation:** each storage can provide different
metadata, e.g. storage based on file-system `FileStorage` can provide
timestampts for file creation time, update time and access time;
S3 storage can provide MD5 hash of content without loading it from
remote bucket, etc. So we need some dynamic and extendable metadata
representation, `Map<String, String>` could be good for this. Another
problem to solve - storage API may be different - so most probably we
always need to check existance of some metadata fields here.
Also, we may want to select custom tuples of metadata from intermediate
representation, so we need some flexible API to read it.

**Solution:** `Meta` interface with single abstract method `<T> T
read(ReadOperator<T>)` was introduced to query metadata object.
`Meta` implementation depends on storage internals, e.g. for S3
it encapsulates `HeadObjectResponse` for FS - `BasicFileAttributes`.
Also, added `WriteOperator<T>` and simple implementation of both
interfaces to encapsulate metadata key and use same object for reading
and writing. `ReadOperator` could be implemented by client to combine
multiple operators into tuples to merge metadata results.
Write operators could be added later with bckward compatibility without
affecting current code.

Closes: #346