### PR TITLE
Compare keys by string representation

### DIFF
--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -201,7 +201,7 @@ public final class FileStorage implements Storage {
     @Override
     public CompletableFuture<Content> value(final Key key) {
         final CompletableFuture<Content> res;
-        if (Key.ROOT.equals(key)) {
+        if (Key.ROOT.string().equals(key.string())) {
             res = new CompletableFutureSupport.Failed<Content>(
                 new ArtipieIOException("Unable to load from root")
             ).get();

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -89,7 +89,7 @@ public final class FileStorage implements Storage {
                 final Collection<Key> keys;
                 if (Files.exists(path)) {
                     final int dirnamelen;
-                    if (Key.ROOT.equals(prefix)) {
+                    if (Key.ROOT.string().equals(prefix.string())) {
                         dirnamelen = path.toString().length() + 1;
                     } else {
                         dirnamelen = path.toString().length() - prefix.string().length();

--- a/src/test/java/com/artipie/asto/StorageExtension.java
+++ b/src/test/java/com/artipie/asto/StorageExtension.java
@@ -81,7 +81,13 @@ final class StorageExtension
             storages = Arrays.asList(
                 new InMemoryStorage(),
                 this.s3Storage(),
-                new SubStorage(new Key.From("prefix"), new InMemoryStorage()),
+                new SubStorage(new Key.From("mem-prefix"), new InMemoryStorage()),
+                new SubStorage(
+                    new Key.From("file-prefix"),
+                    new FileStorage(Files.createTempDirectory("pref-sub"))
+                ),
+                new SubStorage(Key.ROOT, new InMemoryStorage()),
+                new SubStorage(Key.ROOT, new FileStorage(Files.createTempDirectory("sub"))),
                 new FileStorage(Files.createTempDirectory("junit")),
                 new VertxFileStorage(Files.createTempDirectory("vtxjunit"), this.vertx),
                 new BenchmarkStorage(new InMemoryStorage())

--- a/src/test/java/com/artipie/asto/StorageListTest.java
+++ b/src/test/java/com/artipie/asto/StorageListTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since 0.14
  */
 @ExtendWith(StorageExtension.class)
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class StorageListTest {
 
     @TestTemplate
@@ -29,6 +30,22 @@ public final class StorageListTest {
             .map(Key::string)
             .collect(Collectors.toList());
         MatcherAssert.assertThat(keys, Matchers.empty());
+    }
+
+    @TestTemplate
+    void shouldListAllItemsByRootKey(final Storage storage) throws Exception {
+        final BlockingStorage blocking = new BlockingStorage(storage);
+        blocking.save(new Key.From("one", "file.txt"), new byte[]{});
+        blocking.save(new Key.From("one", "two", "file.txt"), new byte[]{});
+        blocking.save(new Key.From("another"), new byte[]{});
+        final Collection<String> keys = blocking.list(Key.ROOT)
+            .stream()
+            .map(Key::string)
+            .collect(Collectors.toList());
+        MatcherAssert.assertThat(
+            keys,
+            Matchers.hasItems("one/file.txt", "one/two/file.txt", "another")
+        );
     }
 
     @TestTemplate


### PR DESCRIPTION
Closes #371 
The problem is described in #371, but what is actually wrong is to call equals on keys like
`Key.ROOT.equals(anotherKey)` 
as in the case with `SubStorage` `anotherKey` is an instance of `SubStorage.PrefixedKey`, not `Key.From` and `equals()` (this is the `equals()` overridden in Key.From` class) will return false.

I've fixed it by comparing keys by their string representations, added various `SubStorage`'s to `StorageExtension` and test with `Key.ROOT` to `StorageListTest`.