### PR TITLE
fix: prevent file to be written out of FileStorage scope

### DIFF
--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -125,6 +125,10 @@ public final class FileStorage implements Storage {
 
     @Override
     public CompletableFuture<Void> save(final Key key, final Content content) {
+        final Path next = this.dir.resolve(key.string());
+        if (!next.normalize().startsWith(next)) {
+            throw new IllegalStateException("Entry path is out of storage.");
+        }
         return CompletableFuture.supplyAsync(
             () -> {
                 final Path tmp = Paths.get(

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -127,7 +127,7 @@ public final class FileStorage implements Storage {
     public CompletableFuture<Void> save(final Key key, final Content content) {
         final Path next = this.dir.resolve(key.string());
         if (!next.normalize().startsWith(next)) {
-            throw new IllegalStateException("Entry path is out of storage.");
+            throw new ArtipieException("Entry path is out of storage.");
         }
         return CompletableFuture.supplyAsync(
             () -> {

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -9,6 +9,7 @@ import com.artipie.asto.fs.FileStorage;
 import io.reactivex.Emitter;
 import io.reactivex.Flowable;
 import io.reactivex.functions.Consumer;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -119,11 +120,9 @@ final class FileStorageTest {
 
     @Test
     void shouldAlwaysDeleteInStorageSandbox() throws IOException {
-        final Path myfolder = this.tmp.resolve("my-folder");
-        myfolder.toFile().mkdirs();
-        myfolder.resolve("file.txt").toFile().createNewFile();
-        final Path afolder = this.tmp.resolve("another-folder");
-        afolder.toFile().mkdirs();
+        final Path myfolder = FileStorageTest.createNewDirectory(this.tmp, "my-folder");
+        FileStorageTest.createNewFile(myfolder, "file.txt");
+        final Path afolder = FileStorageTest.createNewDirectory(this.tmp, "another-folder");
         final FileStorage sto = new FileStorage(afolder);
         final Key key = new Key.From("../my-folder/file.txt");
         final Exception cex = Assertions.assertThrows(
@@ -144,11 +143,11 @@ final class FileStorageTest {
 
     @Test
     void shouldAlwaysMoveFromStorageSandbox() throws IOException {
-        final Path myfolder = this.tmp.resolve("my-folder-move-from");
-        myfolder.toFile().mkdirs();
-        myfolder.resolve("file.txt").toFile().createNewFile();
-        final Path afolder = this.tmp.resolve("another-folder-move-from");
-        afolder.toFile().mkdirs();
+        final Path myfolder =
+            FileStorageTest.createNewDirectory(this.tmp, "my-folder-move-from");
+        FileStorageTest.createNewFile(myfolder, "file.txt");
+        final Path afolder =
+            FileStorageTest.createNewDirectory(this.tmp, "another-folder-move-from");
         final FileStorage sto = new FileStorage(afolder);
         final Key source = new Key.From("../my-folder-move-from/file.txt");
         final Key destination = new Key.From("another-folder-move-from/file.txt");
@@ -170,12 +169,12 @@ final class FileStorageTest {
 
     @Test
     void shouldAlwaysMoveToStorageSandbox() throws IOException {
-        final Path myfolder = this.tmp.resolve("my-folder-move-to");
-        myfolder.toFile().mkdirs();
-        myfolder.resolve("file.txt").toFile().createNewFile();
-        final Path afolder = this.tmp.resolve("another-folder-move-to");
-        afolder.toFile().mkdirs();
-        afolder.resolve("file.txt").toFile().createNewFile();
+        final Path myfolder =
+            FileStorageTest.createNewDirectory(this.tmp, "my-folder-move-to");
+        FileStorageTest.createNewFile(myfolder, "file.txt");
+        final Path afolder =
+            FileStorageTest.createNewDirectory(this.tmp, "another-folder-move-to");
+        FileStorageTest.createNewFile(afolder, "file.txt");
         final FileStorage sto = new FileStorage(afolder);
         final Key source = new Key.From("another-folder-move-to/file.txt");
         final Key destination = new Key.From("../my-folder-move-to/file.txt");
@@ -304,6 +303,34 @@ final class FileStorageTest {
             Files.exists(this.tmp.resolve("one/file.txt")),
             new IsEqual<>(true)
         );
+    }
+
+    /**
+     * Create a directory.
+     * @param parent Directory parent path
+     * @param dirname Directory name
+     * @return Path of directory
+     */
+    private static Path createNewDirectory(final Path parent, final String dirname) {
+        final Path dir = parent.resolve(dirname);
+        dir.toFile().mkdirs();
+        return dir;
+    }
+
+    /**
+     * Create a file.
+     * @param parent Parent file path
+     * @param filename File name
+     * @return File created
+     * @throws IOException If fails to create
+     */
+    private static File createNewFile(
+        final Path parent,
+        final String filename
+    ) throws IOException {
+        final File file = parent.resolve(filename).toFile();
+        file.createNewFile();
+        return file;
     }
 
     /**

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -131,12 +131,12 @@ final class FileStorageTest {
             () -> sto.delete(key).get()
         );
         MatcherAssert.assertThat(
-            "Should throw an io exception while saving",
+            "Should throw an io exception while deleting",
             ExceptionUtils.getRootCause(cex).getClass(),
             new IsEqual<>(IOException.class)
         );
         MatcherAssert.assertThat(
-            "Should throw with exception message while saving",
+            "Should throw with exception message while deleting",
             ExceptionUtils.getRootCause(cex).getMessage(),
             new IsEqual<>(String.format("Entry path is out of storage: %s", key))
         );
@@ -157,12 +157,12 @@ final class FileStorageTest {
             () -> sto.move(source, destination).get()
         );
         MatcherAssert.assertThat(
-            "Should throw an io exception while saving",
+            "Should throw an io exception while moving from",
             ExceptionUtils.getRootCause(cex).getClass(),
             new IsEqual<>(IOException.class)
         );
         MatcherAssert.assertThat(
-            "Should throw with exception message while saving",
+            "Should throw with exception message while moving from",
             ExceptionUtils.getRootCause(cex).getMessage(),
             new IsEqual<>(String.format("Entry path is out of storage: %s", source))
         );
@@ -184,12 +184,12 @@ final class FileStorageTest {
             () -> sto.move(source, destination).get()
         );
         MatcherAssert.assertThat(
-            "Should throw an io exception while saving",
+            "Should throw an io exception while moving to",
             ExceptionUtils.getRootCause(cex).getClass(),
             new IsEqual<>(IOException.class)
         );
         MatcherAssert.assertThat(
-            "Should throw with exception message while saving",
+            "Should throw with exception message while moving to",
             ExceptionUtils.getRootCause(cex).getMessage(),
             new IsEqual<>(String.format("Entry path is out of storage: %s", destination))
         );

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -21,6 +21,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -33,7 +34,7 @@ import org.junit.jupiter.api.io.TempDir;
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 final class FileStorageTest {
 
     /**
@@ -93,6 +94,16 @@ final class FileStorageTest {
         MatcherAssert.assertThat(
             this.storage.list(Key.ROOT).join(),
             new IsEmptyCollection<>()
+        );
+    }
+
+    @Test
+    void shouldAlwaysWriteInStorageSandbox() {
+        Assertions.assertThrows(
+            IllegalStateException.class, () -> {
+                this.storage.save(new Key.From("../../etc/password"), Content.EMPTY).get();
+            },
+            "Entry path is out of storage"
         );
     }
 

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Test case for {@link Storage}.
+ * Test case for {@link FileStorage}.
  *
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
@@ -99,21 +99,99 @@ final class FileStorageTest {
     }
 
     @Test
-    void shouldAlwaysWriteInStorageSandbox() {
+    void shouldAlwaysSaveInStorageSandbox() {
         final Key key = new Key.From("../../etc/password");
         final Exception cex = Assertions.assertThrows(
             Exception.class,
             () -> this.storage.save(key, Content.EMPTY).get()
         );
         MatcherAssert.assertThat(
-            "Should throw an io exception",
+            "Should throw an io exception while saving",
             ExceptionUtils.getRootCause(cex).getClass(),
             new IsEqual<>(IOException.class)
         );
         MatcherAssert.assertThat(
-            "Should throw with exception message",
+            "Should throw with exception message while saving",
             ExceptionUtils.getRootCause(cex).getMessage(),
             new IsEqual<>(String.format("Entry path is out of storage: %s", key))
+        );
+    }
+
+    @Test
+    void shouldAlwaysDeleteInStorageSandbox() throws IOException {
+        final Path myfolder = this.tmp.resolve("my-folder");
+        myfolder.toFile().mkdirs();
+        myfolder.resolve("file.txt").toFile().createNewFile();
+        final Path afolder = this.tmp.resolve("another-folder");
+        afolder.toFile().mkdirs();
+        final FileStorage sto = new FileStorage(afolder);
+        final Key key = new Key.From("../my-folder/file.txt");
+        final Exception cex = Assertions.assertThrows(
+            Exception.class,
+            () -> sto.delete(key).get()
+        );
+        MatcherAssert.assertThat(
+            "Should throw an io exception while saving",
+            ExceptionUtils.getRootCause(cex).getClass(),
+            new IsEqual<>(IOException.class)
+        );
+        MatcherAssert.assertThat(
+            "Should throw with exception message while saving",
+            ExceptionUtils.getRootCause(cex).getMessage(),
+            new IsEqual<>(String.format("Entry path is out of storage: %s", key))
+        );
+    }
+
+    @Test
+    void shouldAlwaysMoveFromStorageSandbox() throws IOException {
+        final Path myfolder = this.tmp.resolve("my-folder-move-from");
+        myfolder.toFile().mkdirs();
+        myfolder.resolve("file.txt").toFile().createNewFile();
+        final Path afolder = this.tmp.resolve("another-folder-move-from");
+        afolder.toFile().mkdirs();
+        final FileStorage sto = new FileStorage(afolder);
+        final Key source = new Key.From("../my-folder-move-from/file.txt");
+        final Key destination = new Key.From("another-folder-move-from/file.txt");
+        final Exception cex = Assertions.assertThrows(
+            Exception.class,
+            () -> sto.move(source, destination).get()
+        );
+        MatcherAssert.assertThat(
+            "Should throw an io exception while saving",
+            ExceptionUtils.getRootCause(cex).getClass(),
+            new IsEqual<>(IOException.class)
+        );
+        MatcherAssert.assertThat(
+            "Should throw with exception message while saving",
+            ExceptionUtils.getRootCause(cex).getMessage(),
+            new IsEqual<>(String.format("Entry path is out of storage: %s", source))
+        );
+    }
+
+    @Test
+    void shouldAlwaysMoveToStorageSandbox() throws IOException {
+        final Path myfolder = this.tmp.resolve("my-folder-move-to");
+        myfolder.toFile().mkdirs();
+        myfolder.resolve("file.txt").toFile().createNewFile();
+        final Path afolder = this.tmp.resolve("another-folder-move-to");
+        afolder.toFile().mkdirs();
+        afolder.resolve("file.txt").toFile().createNewFile();
+        final FileStorage sto = new FileStorage(afolder);
+        final Key source = new Key.From("another-folder-move-to/file.txt");
+        final Key destination = new Key.From("../my-folder-move-to/file.txt");
+        final Exception cex = Assertions.assertThrows(
+            Exception.class,
+            () -> sto.move(source, destination).get()
+        );
+        MatcherAssert.assertThat(
+            "Should throw an io exception while saving",
+            ExceptionUtils.getRootCause(cex).getClass(),
+            new IsEqual<>(IOException.class)
+        );
+        MatcherAssert.assertThat(
+            "Should throw with exception message while saving",
+            ExceptionUtils.getRootCause(cex).getMessage(),
+            new IsEqual<>(String.format("Entry path is out of storage: %s", destination))
         );
     }
 

--- a/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.asto;
 
+import com.artipie.ArtipieException;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.fs.FileStorage;
 import io.reactivex.Emitter;
@@ -100,9 +101,11 @@ final class FileStorageTest {
     @Test
     void shouldAlwaysWriteInStorageSandbox() {
         Assertions.assertThrows(
-            IllegalStateException.class, () -> {
-                this.storage.save(new Key.From("../../etc/password"), Content.EMPTY).get();
-            },
+            ArtipieException.class,
+            () -> this.storage.save(
+                new Key.From("../../etc/password"),
+                Content.EMPTY
+            ).get(),
             "Entry path is out of storage"
         );
     }


### PR DESCRIPTION
Closes #332

Throw an exception when attempting to write out of `FileStorage` scope