### PR TITLE
fix(fs): check path for FS read

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,11 @@ SOFTWARE.
       <artifactId>hamcrest</artifactId>
       <version>2.2</version>
     </dependency>
+    <dependency>
+      <groupId>wtf.g4s8</groupId>
+      <artifactId>tuples</artifactId>
+      <version>0.1.2</version>
+    </dependency>
     <!-- TestNG compatibility layer with Junit5 -->
     <dependency>
       <groupId>com.github.testng-team</groupId>


### PR DESCRIPTION
Refactor key path validation to use futures.
Check read key path before performing content reading.

Ref: #332