### PR TITLE
feat: introduce helper for Meta's standard methods

### DIFF
--- a/src/main/java/com/artipie/asto/MetaCommon.java
+++ b/src/main/java/com/artipie/asto/MetaCommon.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto;
+
+import com.artipie.ArtipieException;
+
+/**
+ * Helper object to read common metadata from {@link Meta}.
+ * @since 1.11
+ */
+public final class MetaCommon {
+
+    /**
+     * Metadata.
+     */
+    private final Meta meta;
+
+    /**
+     * Ctor.
+     * @param meta Metadata
+     */
+    public MetaCommon(final Meta meta) {
+        this.meta = meta;
+    }
+
+    /**
+     * Size.
+     * @return Size
+     */
+    public long size() {
+        return this.meta.read(Meta.OP_SIZE).orElseThrow(
+            () -> new ArtipieException("SIZE couldn't be read")
+        ).longValue();
+    }
+}

--- a/src/test/java/com/artipie/asto/MetaCommonTest.java
+++ b/src/test/java/com/artipie/asto/MetaCommonTest.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto;
+
+import com.artipie.asto.memory.InMemoryStorage;
+import java.nio.charset.StandardCharsets;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link MetaCommon}.
+ * @since 1.11
+ */
+final class MetaCommonTest {
+
+    @Test
+    void readsSize() {
+        final Storage storage = new InMemoryStorage();
+        final Key key = new Key.From("key");
+        final String data = "012004407";
+        storage.save(
+            key,
+            new Content.From(data.getBytes(StandardCharsets.UTF_8))
+        );
+        MatcherAssert.assertThat(
+            "Gets value size from metadata",
+            new MetaCommon(storage.metadata(key).join()).size(),
+            new IsEqual<>(Long.valueOf(data.length()))
+        );
+    }
+
+}


### PR DESCRIPTION
We implemented `size` method to start.

Close: #393