### PR TITLE
fix(storage): add metadata method to standard decorator

### DIFF
--- a/src/main/java/com/artipie/asto/Storage.java
+++ b/src/main/java/com/artipie/asto/Storage.java
@@ -199,5 +199,10 @@ public interface Storage {
         ) {
             return this.delegate.exclusively(key, operation);
         }
+
+        @Override
+        public final CompletableFuture<? extends Meta> metadata(final Key key) {
+            return this.delegate.metadata(key);
+        }
     }
 }

--- a/src/test/java/com/artipie/asto/StorageExtension.java
+++ b/src/test/java/com/artipie/asto/StorageExtension.java
@@ -121,7 +121,8 @@ final class StorageExtension
                     new SubStorage(Key.ROOT, new FileStorage(Files.createTempDirectory("sub"))),
                     new FileStorage(Files.createTempDirectory("junit")),
                     new VertxFileStorage(Files.createTempDirectory("vtxjunit"), this.vertx),
-                    new BenchmarkStorage(new InMemoryStorage())
+                    new BenchmarkStorage(new InMemoryStorage()),
+                    new StorageWrapped(new InMemoryStorage())
                 )
             );
             if (!SystemUtils.IS_OS_WINDOWS) {

--- a/src/test/java/com/artipie/asto/StorageWrapped.java
+++ b/src/test/java/com/artipie/asto/StorageWrapped.java
@@ -1,0 +1,23 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto;
+
+/**
+ * Storage that extends {@link Storage.Wrap}.
+ *
+ * <p>
+ * It's to ensure that {@link Storage.Wrap} implements all methods of {@link Storage}.
+ * </p>
+ * @since 1.11
+ */
+final class StorageWrapped extends Storage.Wrap implements Storage {
+    /**
+     * Ctor.
+     * @param storage Storage to wrap
+     */
+    protected StorageWrapped(final Storage storage) {
+        super(storage);
+    }
+}


### PR DESCRIPTION
We missed to add method `metadata` in `Storage.Wrap`. Here, we fix it.

Fix: #392