### PR TITLE
fix: change way we check that key path is contained in `FileStorage` location

### DIFF
--- a/src/main/java/com/artipie/asto/KeyPath.java
+++ b/src/main/java/com/artipie/asto/KeyPath.java
@@ -39,7 +39,7 @@ public final class KeyPath {
      * @param key Key to transform
      */
     public KeyPath(final Path root, final Key key) {
-        this.root = root;
+        this.root = root.normalize();
         this.key = key;
     }
 
@@ -53,13 +53,12 @@ public final class KeyPath {
      * @return Path future
      */
     public Path get() {
-        final Path path = this.root.resolve(this.key.string());
-        final Path pathn = path.normalize();
-        if (pathn.startsWith(this.root)) {
-            return pathn;
+        final Path path = this.root.resolve(this.key.string()).normalize();
+        if (path.startsWith(this.root)) {
+            return path;
         } else {
             throw new ArtipieIOException(
-                String.format("Entry path is out of root location: %s", pathn)
+                String.format("Entry path is out of root location: %s", path)
             );
         }
     }

--- a/src/main/java/com/artipie/asto/KeyPath.java
+++ b/src/main/java/com/artipie/asto/KeyPath.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Converts key to path.
+ *
+ * @since 1.11
+ */
+public final class KeyPath {
+
+    /**
+     * Root.
+     */
+    private final Path root;
+
+    /**
+     * Key to transform.
+     */
+    private final Key key;
+
+    /**
+     * Ctor.
+     * @param root Root path in string
+     * @param key Key to transform
+     */
+    public KeyPath(final String root, final Key key) {
+        this(Paths.get(root), key);
+    }
+
+    /**
+     * Ctor.
+     * @param root Root
+     * @param key Key to transform
+     */
+    public KeyPath(final Path root, final Key key) {
+        this.root = root;
+        this.key = key;
+    }
+
+    /**
+     * Get path of the key.
+     * <p>
+     * Validates that the path is in root location and converts it to path.
+     * Fails with {@link ArtipieIOException} if key is out of root location.
+     * </p>
+     *
+     * @return Path future
+     */
+    public Path get() {
+        final Path path = this.root.resolve(this.key.string());
+        final Path pathn = path.normalize();
+        if (pathn.startsWith(this.root)) {
+            return pathn;
+        } else {
+            throw new ArtipieIOException(
+                String.format("Entry path is out of root location: %s", pathn)
+            );
+        }
+    }
+}

--- a/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -8,6 +8,7 @@ import com.artipie.ArtipieException;
 import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
+import com.artipie.asto.KeyPath;
 import com.artipie.asto.Meta;
 import com.artipie.asto.OneTimePublisher;
 import com.artipie.asto.Storage;
@@ -295,16 +296,11 @@ public final class FileStorage implements Storage {
      * @return Path future
      */
     private CompletableFuture<? extends Path> keyPath(final Key key) {
-        final Path path = this.dir.resolve(key.string());
         final CompletableFuture<Path> res = new CompletableFuture<>();
-        if (path.normalize().startsWith(path)) {
-            res.complete(path);
-        } else {
-            res.completeExceptionally(
-                new ArtipieIOException(
-                    String.format("Entry path is out of storage: %s", key)
-                )
-            );
+        try {
+            res.complete(new KeyPath(this.dir, key).get());
+        } catch (final ArtipieIOException aio) {
+            res.completeExceptionally(aio);
         }
         return res;
     }

--- a/src/test/java/com/artipie/asto/KeyPathTest.java
+++ b/src/test/java/com/artipie/asto/KeyPathTest.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link KeyPath}.
+ *
+ * @since 1.11
+ * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
+ */
+final class KeyPathTest {
+
+    @Test
+    void validatesThatPathIsInRootLocation() {
+        MatcherAssert.assertThat(
+            "Should validate simple relative key",
+            new KeyPath(
+                "/x/y",
+                new Key.From("z")
+            ).get().toString(),
+            new IsEqual<>("/x/y/z")
+        );
+        MatcherAssert.assertThat(
+            "Should validate key with redundant ..",
+            new KeyPath(
+                "/a/b/c",
+                new Key.From("../c/d")
+            ).get().toString(),
+            new IsEqual<>("/a/b/c/d")
+        );
+        MatcherAssert.assertThat(
+            "Should validate key with redundant .",
+            new KeyPath(
+                "/f/g/h",
+                new Key.From("./i")
+            ).get().toString(),
+            new IsEqual<>("/f/g/h/i")
+        );
+        MatcherAssert.assertThat(
+            "Should validate key with root location containing redundant .",
+            new KeyPath(
+                "/f/g/.././h",
+                new Key.From("i")
+            ).get().toString(),
+            new IsEqual<>("/f/h/i")
+        );
+    }
+
+    @Test
+    void throwsExceptionWhenOutOfRoot() {
+        final ArtipieIOException aie = Assertions.assertThrows(
+            ArtipieIOException.class,
+            () -> new KeyPath("/k/l/m", new Key.From("../n/o")).get()
+        );
+        MatcherAssert.assertThat(
+            "Should throw with exception message",
+            ExceptionUtils.getRootCause(aie).getLocalizedMessage(),
+            new IsEqual<>("Entry path is out of root location: /k/l/n/o")
+        );
+    }
+}


### PR DESCRIPTION
We noticed that when the key path contains a `.` element, we get an exception saying that the entry path is not in storage location.
We refactored `FileStorage` by introducing a class `KeyPath` to easily fix the bug.

Cc: artipie/artipie#995