### PR TITLE
feat: Storage for artipie/files-adapter via HTTP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,17 @@ SOFTWARE.
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.artipie</groupId>
+      <artifactId>http-client</artifactId>
+      <version>0.3.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.artipie</groupId>
+          <artifactId>asto</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/src/main/java/com/artipie/asto/ArtipieStorage.java
+++ b/src/main/java/com/artipie/asto/ArtipieStorage.java
@@ -123,7 +123,8 @@ public final class ArtipieStorage implements Storage {
                 if (status.success()) {
                     res = CompletableFuture.allOf();
                 } else {
-                    res = CompletableFuture.failedFuture(
+                    res = new CompletableFuture<>();
+                    res.completeExceptionally(
                         new ArtipieIOException(
                             String.format(
                                 "Entry is not created [key=%s, status=%s]",
@@ -195,7 +196,8 @@ public final class ArtipieStorage implements Storage {
                 if (status.success()) {
                     res = CompletableFuture.allOf();
                 } else {
-                    res = CompletableFuture.failedFuture(
+                    res = new CompletableFuture<>();
+                    res.completeExceptionally(
                         new ArtipieIOException(
                             String.format(
                                 "Entry is not deleted [key=%s, status=%s]",

--- a/src/main/java/com/artipie/asto/ArtipieStorage.java
+++ b/src/main/java/com/artipie/asto/ArtipieStorage.java
@@ -122,11 +122,11 @@ public final class ArtipieStorage implements Storage {
             content
         ).send(
             (status, rsheaders, rsbody) -> {
-                final CompletableFuture<Void> res;
+                final CompletionStage<Void> res;
                 if (status.success()) {
                     res = CompletableFuture.allOf();
                 } else {
-                    res = CompletableFuture.failedFuture(
+                    res = new FailedCompletionStage<>(
                         new ArtipieIOException(
                             String.format(
                                 "Entry is not created [key=%s, status=%s]",
@@ -190,11 +190,11 @@ public final class ArtipieStorage implements Storage {
             Content.EMPTY
         ).send(
             (status, rsheaders, rsbody) -> {
-                final CompletableFuture<Void> res;
+                final CompletionStage<Void> res;
                 if (status.success()) {
                     res = CompletableFuture.allOf();
                 } else {
-                    res = CompletableFuture.failedFuture(
+                    res = new FailedCompletionStage<>(
                         new ArtipieIOException(
                             String.format(
                                 "Entry is not deleted [key=%s, status=%s]",

--- a/src/main/java/com/artipie/asto/ArtipieStorage.java
+++ b/src/main/java/com/artipie/asto/ArtipieStorage.java
@@ -1,0 +1,247 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto;
+
+import com.artipie.asto.ext.PublisherAs;
+import com.artipie.http.Headers;
+import com.artipie.http.Slice;
+import com.artipie.http.client.ClientSlices;
+import com.artipie.http.client.UriClientSlice;
+import com.artipie.http.client.auth.AuthClientSlice;
+import com.artipie.http.client.auth.Authenticator;
+import com.artipie.http.headers.ContentLength;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rq.RqMethod;
+import io.reactivex.Flowable;
+import java.io.StringReader;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.json.Json;
+import javax.json.JsonReader;
+import javax.json.JsonString;
+
+/**
+ * Proxy storage for a file-adapter via HTTP.
+ *
+ * @since 1.11.0
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class ArtipieStorage implements Storage {
+
+    /**
+     * Remote slice.
+     */
+    private final Slice remote;
+
+    /**
+     * New storage slice.
+     *
+     * @param clients HTTP clients
+     * @param remote Remote URI
+     */
+    public ArtipieStorage(final ClientSlices clients, final URI remote) {
+        this(new UriClientSlice(clients, remote));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param remote Remote slice
+     */
+    ArtipieStorage(final Slice remote) {
+        this.remote = remote;
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param clients HTTP clients
+     * @param remote Remote URI
+     * @param auth Authenticator
+     */
+    public ArtipieStorage(final ClientSlices clients, final URI remote,
+        final Authenticator auth) {
+        this(
+            new AuthClientSlice(new UriClientSlice(clients, remote), auth)
+        );
+    }
+
+    @Override
+    public CompletableFuture<Boolean> exists(final Key key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<Collection<Key>> list(final Key prefix) {
+        final CompletableFuture<Collection<Key>> promise = new CompletableFuture<>();
+        this.remote.response(
+            new RequestLine(RqMethod.GET, ArtipieStorage.uri(prefix)).toString(),
+            new Headers.From("Accept", "application/json"),
+            Content.EMPTY
+        ).send(
+            (status, rsheaders, rsbody) -> {
+                final CompletableFuture<Void> term = new CompletableFuture<>();
+                if (status.success()) {
+                    new PublisherAs(
+                        Flowable.fromPublisher(rsbody)
+                            .doOnError(term::completeExceptionally)
+                            .doOnTerminate(() -> term.complete(null))
+                    ).string(StandardCharsets.UTF_8)
+                        .thenApply(s -> promise.complete(ArtipieStorage.parse(s)));
+                } else {
+                    final String msg = String.format(
+                        "Cannot get lists blobs contained in given path [prefix=%s, status=%s]",
+                        prefix,
+                        status
+                    );
+                    promise.completeExceptionally(
+                        new ArtipieIOException(msg)
+                    );
+                }
+                return term;
+            }
+        );
+        return promise;
+    }
+
+    @Override
+    public CompletableFuture<Void> save(final Key key, final Content content) {
+        return this.remote.response(
+            new RequestLine(RqMethod.PUT, ArtipieStorage.uri(key)).toString(),
+            new Headers.From(new ContentLength(content.size().get())),
+            content
+        ).send(
+            (status, rsheaders, rsbody) -> {
+                final CompletableFuture<Void> res;
+                if (status.success()) {
+                    res = CompletableFuture.allOf();
+                } else {
+                    res = CompletableFuture.failedFuture(
+                        new ArtipieIOException(
+                            String.format(
+                                "Entry is not created [key=%s, status=%s]",
+                                key,
+                                status
+                            )
+                        )
+                    );
+                }
+                return res;
+            }
+        ).toCompletableFuture();
+    }
+
+    @Override
+    public CompletableFuture<Void> move(final Key source, final Key destination) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<? extends Meta> metadata(final Key key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<Content> value(final Key key) {
+        final CompletableFuture<Content> promise = new CompletableFuture<>();
+        this.remote.response(
+            new RequestLine(RqMethod.GET, ArtipieStorage.uri(key)).toString(),
+            Headers.EMPTY,
+            Content.EMPTY
+        ).send(
+            (status, rsheaders, rsbody) -> {
+                final CompletableFuture<Void> term = new CompletableFuture<>();
+                if (status.success()) {
+                    promise.complete(
+                        new Content.From(
+                            Flowable.fromPublisher(rsbody)
+                                .doOnError(term::completeExceptionally)
+                                .doOnTerminate(() -> term.complete(null))
+                        )
+                    );
+                } else {
+                    promise.completeExceptionally(
+                        new ArtipieIOException(
+                            String.format(
+                                "Cannot get a value [key=%s, status=%s]",
+                                key,
+                                status
+                            )
+                        )
+                    );
+                }
+                return term;
+            }
+        );
+        return promise;
+    }
+
+    @Override
+    public CompletableFuture<Void> delete(final Key key) {
+        return this.remote.response(
+            new RequestLine(RqMethod.DELETE, ArtipieStorage.uri(key)).toString(),
+            Headers.EMPTY,
+            Content.EMPTY
+        ).send(
+            (status, rsheaders, rsbody) -> {
+                final CompletableFuture<Void> res;
+                if (status.success()) {
+                    res = CompletableFuture.allOf();
+                } else {
+                    res = CompletableFuture.failedFuture(
+                        new ArtipieIOException(
+                            String.format(
+                                "Entry is not deleted [key=%s, status=%s]",
+                                key,
+                                status
+                            )
+                        )
+                    );
+                }
+                return res;
+            }
+        ).toCompletableFuture();
+    }
+
+    @Override
+    public <T> CompletionStage<T> exclusively(
+        final Key key,
+        final Function<Storage, CompletionStage<T>> operation) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Parse JSON array of keys.
+     *
+     * @param json JSON array of keys.
+     * @return Collection of keys.
+     */
+    private static Collection<Key> parse(final String json) {
+        try (
+            JsonReader reader = Json.createReader(new StringReader(json))
+        ) {
+            return reader.readArray()
+                .stream()
+                .map(v -> (JsonString) v)
+                .map(js -> new Key.From(js.getString()))
+                .collect(Collectors.toList());
+        }
+    }
+
+    /**
+     * Converts key to URI string.
+     *
+     * @param key Key.
+     * @return URI string.
+     */
+    private static String uri(final Key key) {
+        return String.format("/%s", key);
+    }
+}

--- a/src/test/java/com/artipie/asto/ArtipieStorageTest.java
+++ b/src/test/java/com/artipie/asto/ArtipieStorageTest.java
@@ -1,0 +1,279 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto;
+
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.ext.PublisherAs;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.client.ClientSlices;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rq.RqHeaders;
+import com.artipie.http.rq.RqMethod;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithBody;
+import com.artipie.http.rs.RsWithStatus;
+import com.artipie.http.rs.StandardRs;
+import com.artipie.http.slice.SliceSimple;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsEmptyIterable;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link ArtipieStorage}.
+ *
+ * @since 1.11.0
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class ArtipieStorageTest {
+
+    @Test
+    void shouldSave() throws Exception {
+        final Key key = new Key.From("a", "b", "hello.txt");
+        final byte[] content = "Hello world!!!".getBytes();
+        final AtomicReference<String> line = new AtomicReference<>();
+        final AtomicReference<Iterable<Map.Entry<String, String>>> headers =
+            new AtomicReference<>();
+        final AtomicReference<byte[]> body = new AtomicReference<>();
+        new BlockingStorage(
+            new ArtipieStorage(
+                new FakeClientSlices(
+                    (rqline, rqheaders, rqbody) -> {
+                        line.set(rqline);
+                        headers.set(rqheaders);
+                        return new AsyncResponse(
+                            new PublisherAs(rqbody).bytes().thenApply(
+                                bytes -> {
+                                    body.set(bytes);
+                                    return StandardRs.OK;
+                                }
+                            )
+                        );
+                    }
+                ), new URI("http://host/path1")
+            )
+        ).save(key, content);
+        MatcherAssert.assertThat(
+            line.get(),
+            new IsEqual<>(
+                new RequestLine(
+                    RqMethod.PUT, String.format("/path1/%s", key)
+                ).toString()
+            )
+        );
+        MatcherAssert.assertThat(
+            new RqHeaders(headers.get(), "content-length"),
+            Matchers.contains(String.valueOf(content.length))
+        );
+        MatcherAssert.assertThat(
+            body.get(),
+            new IsEqual<>(content)
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSavingIsFailed() {
+        ArtipieStorageTest.assertThrowException(
+            () -> new ArtipieStorage(
+                new SliceSimple(
+                    new RsWithStatus(RsStatus.INTERNAL_ERROR)
+                )
+            ).save(new Key.From("1"), Content.EMPTY)
+        );
+    }
+
+    @Test
+    void shouldDelete() throws Exception {
+        final Key key = new Key.From("delkey");
+        final AtomicReference<String> line = new AtomicReference<>();
+        final AtomicReference<Iterable<Map.Entry<String, String>>> headers =
+            new AtomicReference<>();
+        final AtomicReference<byte[]> body = new AtomicReference<>();
+        new BlockingStorage(
+            new ArtipieStorage(
+                new FakeClientSlices(
+                    (rqline, rqheaders, rqbody) -> {
+                        line.set(rqline);
+                        headers.set(rqheaders);
+                        return new AsyncResponse(
+                            new PublisherAs(rqbody).bytes().thenApply(
+                                bytes -> {
+                                    body.set(bytes);
+                                    return StandardRs.OK;
+                                }
+                            )
+                        );
+                    }
+                ), new URI("http://host/path2")
+            )
+        ).delete(key);
+        MatcherAssert.assertThat(
+            line.get(),
+            new IsEqual<>(
+                new RequestLine(
+                    RqMethod.DELETE, String.format("/path2/%s", key)
+                ).toString()
+            )
+        );
+        MatcherAssert.assertThat(
+            "Headers are empty",
+            headers.get(),
+            new IsEmptyIterable<>()
+        );
+        MatcherAssert.assertThat(
+            "Body is empty",
+            body.get(),
+            new IsEqual<>(new byte[0])
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenDeleteIsFailed() {
+        ArtipieStorageTest.assertThrowException(
+            () -> new ArtipieStorage(
+                new SliceSimple(
+                    new RsWithStatus(RsStatus.INTERNAL_ERROR)
+                )
+            ).delete(new Key.From("a"))
+        );
+    }
+
+    @Test
+    void shouldListKeys() {
+        final Collection<Key> res = new BlockingStorage(
+            new ArtipieStorage(
+                new SliceSimple(
+                    new RsWithBody(
+                        new Content.From(
+                            "[\"a/b/file1.txt\", \"a/file2.txt\"]"
+                                .getBytes(StandardCharsets.UTF_8)
+                        )
+                    )
+                )
+            )
+        ).list(new Key.From("prefix"));
+        MatcherAssert.assertThat(
+            res,
+            Matchers.containsInAnyOrder(
+                new Key.From("a", "b", "file1.txt"),
+                new Key.From("a", "file2.txt")
+            )
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenListIsFailed() {
+        ArtipieStorageTest.assertThrowException(
+            () -> new ArtipieStorage(
+                new SliceSimple(
+                    new RsWithStatus(RsStatus.INTERNAL_ERROR)
+                )
+            ).list(new Key.From("b"))
+        );
+    }
+
+    @Test
+    void shouldGetValue() {
+        final String data = "test data";
+        final String res = new String(
+            new BlockingStorage(
+                new ArtipieStorage(
+                    new SliceSimple(
+                        new RsWithBody(
+                            new Content.From(
+                                data.getBytes(StandardCharsets.UTF_8)
+                            )
+                        )
+                    )
+                )
+            ).value(new Key.From("c")),
+            StandardCharsets.UTF_8
+        );
+        MatcherAssert.assertThat(
+            res,
+            new IsEqual<>(data)
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenValueIsFailed() {
+        ArtipieStorageTest.assertThrowException(
+            () -> new ArtipieStorage(
+                new SliceSimple(
+                    new RsWithStatus(RsStatus.INTERNAL_ERROR)
+                )
+            ).value(new Key.From("key"))
+        );
+    }
+
+    private static void assertThrowException(
+        final Supplier<CompletableFuture<?>> supplier
+    ) {
+        final CompletableFuture<?> res = supplier.get();
+        final Exception exception = Assertions.assertThrows(
+            CompletionException.class,
+            res::join
+        );
+        MatcherAssert.assertThat(
+            "Storage 'ArtipieStorage' should fail",
+            exception.getCause(),
+            new IsInstanceOf(ArtipieIOException.class)
+        );
+    }
+
+    /**
+     * Fake {@link ClientSlices} implementation that returns specified result.
+     *
+     * @since 1.11.0
+     */
+    private static final class FakeClientSlices implements ClientSlices {
+
+        /**
+         * Slice returned by requests.
+         */
+        private final Slice result;
+
+        /**
+         * Ctor.
+         *
+         * @param result Slice returned by requests.
+         */
+        FakeClientSlices(final Slice result) {
+            this.result = result;
+        }
+
+        @Override
+        public Slice http(final String host) {
+            return this.result;
+        }
+
+        @Override
+        public Slice http(final String host, final int port) {
+            return this.result;
+        }
+
+        @Override
+        public Slice https(final String host) {
+            return this.result;
+        }
+
+        @Override
+        public Slice https(final String host, final int port) {
+            return this.result;
+        }
+    }
+}

--- a/src/test/java/com/artipie/asto/ArtipieStorageTest.java
+++ b/src/test/java/com/artipie/asto/ArtipieStorageTest.java
@@ -68,6 +68,7 @@ public final class ArtipieStorageTest {
             )
         ).save(key, content);
         MatcherAssert.assertThat(
+            "Request line to save a value",
             line.get(),
             new IsEqual<>(
                 new RequestLine(
@@ -76,10 +77,12 @@ public final class ArtipieStorageTest {
             )
         );
         MatcherAssert.assertThat(
+            "Content-length header value should be equal to the content length",
             new RqHeaders(headers.get(), "content-length"),
             Matchers.contains(String.valueOf(content.length))
         );
         MatcherAssert.assertThat(
+            "Request body should be equal to the content",
             body.get(),
             new IsEqual<>(content)
         );
@@ -122,6 +125,7 @@ public final class ArtipieStorageTest {
             )
         ).delete(key);
         MatcherAssert.assertThat(
+            "Request line to delete a value",
             line.get(),
             new IsEqual<>(
                 new RequestLine(


### PR DESCRIPTION
Closes #405 
- implemented `Storage` as `ArtipieStorage` for artipie/files-adapter via HTTP
- added tests for `ArtipieStorage`