### PR TITLE
test: fix tests for `LoggingStorage`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,17 +99,6 @@ SOFTWARE.
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.jcabi</groupId>
-      <artifactId>jcabi-log</artifactId>
-      <version>0.20.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>2.0.0-alpha5</version>
-      <scope>test</scope>
-    </dependency>
     <!-- Vert.x dependencies -->
     <dependency>
       <groupId>io.vertx</groupId>

--- a/src/main/java/com/artipie/asto/LoggingStorage.java
+++ b/src/main/java/com/artipie/asto/LoggingStorage.java
@@ -4,20 +4,25 @@
  */
 package com.artipie.asto;
 
-import com.jcabi.log.Logger;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Storage that logs performed operations.
  *
  * @since 0.20.4
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.LoggerIsNotStaticFinal"})
 public final class LoggingStorage implements Storage {
+
+    /**
+     * Logger.
+     */
+    private final Logger logger;
 
     /**
      * Logging level.
@@ -47,6 +52,9 @@ public final class LoggingStorage implements Storage {
     public LoggingStorage(final Level level, final Storage storage) {
         this.level = level;
         this.storage = storage;
+        this.logger = Logger.getLogger(
+            this.storage.getClass().getCanonicalName()
+        );
     }
 
     @Override
@@ -161,6 +169,6 @@ public final class LoggingStorage implements Storage {
      * @param args Optional arguments for string formatting.
      */
     private void log(final String msg, final Object... args) {
-        Logger.log(this.level, this.storage, msg, args);
+        this.logger.log(this.level, String.format(msg, args));
     }
 }


### PR DESCRIPTION
`jcabi-log:0.20.1` does not support recent versions of logging libraries.
So, we replaced it by `java.util.logging`.

Close: #413