### PR TITLE
fix: fixed BucketTest#shouldUploadPartAndCompleteMultipartUpload test

### DIFF
--- a/src/test/java/com/artipie/asto/s3/S3StorageTest.java
+++ b/src/test/java/com/artipie/asto/s3/S3StorageTest.java
@@ -47,11 +47,6 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
  * @since 0.15
  * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #411:30min There two disabled tests for S3 storage:
- *  S3StorageTest#shouldUploadObjectWhenSaveLargeContent and
- *  BucketTest#shouldUploadPartAndCompleteMultipartUpload. These tests fail with
- *  S3Exception: null (Service: S3, Status Code: 400, Request ID: null)
- *  error. Figure out where is the problem, fix it and enable tests.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 @DisabledOnOs(OS.WINDOWS)
@@ -97,7 +92,7 @@ class S3StorageTest {
 
     @Test
     @Timeout(15)
-    @Disabled
+    @Disabled("https://github.com/artipie/asto/issues/421")
     void shouldUploadObjectWhenSaveLargeContent(final AmazonS3 client) throws Exception {
         final int size = 20 * 1024 * 1024;
         final byte[] data = new byte[size];


### PR DESCRIPTION
Close: #414 

`CompleteMultipartUploadRequest` should contain a list of uploaded parts, otherwise an exception will be thrown.