### PR TITLE
fix: added parts information to `CompleteMultipartUploadRequest`

### DIFF
--- a/src/main/java/com/artipie/asto/Splitting.java
+++ b/src/main/java/com/artipie/asto/Splitting.java
@@ -49,7 +49,7 @@ public class Splitting {
         final Publisher<ByteBuffer> res;
         int remaining = this.source.remaining();
         if (remaining > this.size) {
-            final List<ByteBuffer> parts = new ArrayList<>(16);
+            final List<ByteBuffer> parts = new ArrayList<>(remaining / this.size + 1);
             while (remaining > 0) {
                 final byte[] bytes;
                 if (remaining > this.size) {

--- a/src/main/java/com/artipie/asto/Splitting.java
+++ b/src/main/java/com/artipie/asto/Splitting.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto;
+
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import org.reactivestreams.Publisher;
+
+/**
+ * Splits the original ByteBuffer to several ones
+ * with size less or equals defined max size.
+ *
+ * @since 1.12.0
+ */
+public class Splitting {
+
+    /**
+     * Source byte buffer.
+     */
+    private final ByteBuffer source;
+
+    /**
+     * Max size of split byte buffer.
+     */
+    private final int size;
+
+    /**
+     * Ctor.
+     *
+     * @param source Source byte buffer.
+     * @param size Max size of split byte buffer.
+     */
+    public Splitting(final ByteBuffer source, final int size) {
+        this.source = source;
+        this.size = size;
+    }
+
+    /**
+     * Splits the original ByteBuffer to ones with size less
+     * or equals defined max {@code size}.
+     *
+     * @return Publisher of ByteBuffers.
+     */
+    public Publisher<ByteBuffer> publisher() {
+        final Publisher<ByteBuffer> res;
+        int remaining = this.source.remaining();
+        if (remaining > this.size) {
+            final List<ByteBuffer> parts = new ArrayList<>(16);
+            while (remaining > 0) {
+                final byte[] bytes;
+                if (remaining > this.size) {
+                    bytes = new byte[this.size];
+                } else {
+                    bytes = new byte[remaining];
+                }
+                this.source.get(bytes);
+                parts.add(ByteBuffer.wrap(bytes));
+                remaining = this.source.remaining();
+            }
+            res = Flowable.fromIterable(parts);
+        } else {
+            res = Flowable.just(this.source);
+        }
+        return res;
+    }
+}

--- a/src/main/java/com/artipie/asto/s3/MultipartUpload.java
+++ b/src/main/java/com/artipie/asto/s3/MultipartUpload.java
@@ -92,7 +92,7 @@ final class MultipartUpload {
             ).map(
                 chunk -> {
                     final int pnum = counter.incrementAndGet();
-                    return MultipartUpload.this.uploadPart(
+                    return this.uploadPart(
                         pnum,
                         Flowable.just(chunk)
                     ).thenAccept(

--- a/src/main/java/com/artipie/asto/s3/MultipartUpload.java
+++ b/src/main/java/com/artipie/asto/s3/MultipartUpload.java
@@ -95,20 +95,16 @@ final class MultipartUpload {
                     return MultipartUpload.this.uploadPart(
                         pnum,
                         Flowable.just(chunk)
-                    ).<Void>thenApply(
-                        response -> {
-                            this.parts.add(
-                                new UploadedPart(pnum, response.eTag())
-                            );
-                            return null;
-                        }
+                    ).thenAccept(
+                        response -> this.parts.add(
+                            new UploadedPart(pnum, response.eTag())
+                        )
                     );
                 }
             ).reduce(
                 CompletableFuture.allOf(),
                 (acc, stage) -> acc.thenCompose(o -> stage)
             ).to(SingleInterop.get())
-            .toCompletableFuture()
             .thenCompose(Function.identity());
     }
 

--- a/src/main/java/com/artipie/asto/s3/MultipartUpload.java
+++ b/src/main/java/com/artipie/asto/s3/MultipartUpload.java
@@ -6,20 +6,25 @@ package com.artipie.asto.s3;
 
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
+import com.artipie.asto.Splitting;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
-import hu.akarnokd.rxjava2.operators.FlowableTransformers;
 import io.reactivex.Flowable;
 import io.reactivex.Observable;
-import io.reactivex.functions.Predicate;
 import java.nio.ByteBuffer;
+import java.util.Comparator;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.reactivestreams.Publisher;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
@@ -31,9 +36,11 @@ import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 final class MultipartUpload {
 
     /**
-     * Minimum part size. See https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
+     * Minimum part size.
+     * See <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html">
+     * Amazon S3 multipart upload limits</a>
      */
-    private static final long MIN_PART_SIZE = 5 * 1024 * 1024;
+    private static final int MIN_PART_SIZE = 5 * 1024 * 1024;
 
     /**
      * Bucket.
@@ -51,6 +58,11 @@ final class MultipartUpload {
     private final String id;
 
     /**
+     * Uploaded parts.
+     */
+    private final List<UploadedPart> parts;
+
+    /**
      * Ctor.
      *
      * @param bucket Bucket.
@@ -61,6 +73,7 @@ final class MultipartUpload {
         this.bucket = bucket;
         this.key = key;
         this.id = id;
+        this.parts = new CopyOnWriteArrayList<>();
     }
 
     /**
@@ -70,36 +83,33 @@ final class MultipartUpload {
      * @return Completion stage which is completed when responses received from S3 for all parts.
      */
     public CompletionStage<Void> upload(final Content content) {
-        final AtomicInteger part = new AtomicInteger();
-        return Flowable.fromPublisher(content).compose(
-            FlowableTransformers.bufferWhile(
-                new Predicate<ByteBuffer>() {
-                    private long sum;
-
-                    @Override
-                    public boolean test(final ByteBuffer buffer) {
-                        final int length = buffer.remaining();
-                        final boolean keep;
-                        if (this.sum + length > MultipartUpload.MIN_PART_SIZE) {
-                            this.sum = length;
-                            keep = false;
-                        } else {
-                            this.sum += length;
-                            keep = true;
+        final AtomicInteger counter = new AtomicInteger();
+        return Flowable.fromPublisher(content)
+            .concatMap(
+                buffer -> Flowable.fromPublisher(
+                    new Splitting(buffer, MultipartUpload.MIN_PART_SIZE).publisher()
+                )
+            ).map(
+                chunk -> {
+                    final int pnum = counter.incrementAndGet();
+                    return MultipartUpload.this.uploadPart(
+                        pnum,
+                        Flowable.just(chunk)
+                    ).<Void>thenApply(
+                        response -> {
+                            this.parts.add(
+                                new UploadedPart(pnum, response.eTag())
+                            );
+                            return null;
                         }
-                        return keep;
-                    }
+                    );
                 }
-            )
-        ).map(
-            chunk -> this.uploadPart(
-                part.incrementAndGet(),
-                Flowable.fromIterable(chunk)
-            ).<Void>thenApply(ignored -> null)
-        ).reduce(
-            CompletableFuture.allOf(),
-            (acc, stage) -> acc.thenCompose(o -> stage)
-        ).to(SingleInterop.get()).toCompletableFuture().thenCompose(Function.identity());
+            ).reduce(
+                CompletableFuture.allOf(),
+                (acc, stage) -> acc.thenCompose(o -> stage)
+            ).to(SingleInterop.get())
+            .toCompletableFuture()
+            .thenCompose(Function.identity());
     }
 
     /**
@@ -112,6 +122,16 @@ final class MultipartUpload {
             CompleteMultipartUploadRequest.builder()
                 .key(this.key.string())
                 .uploadId(this.id)
+                .multipartUpload(
+                    CompletedMultipartUpload.builder()
+                        .parts(
+                            this.parts.stream()
+                                .sorted(Comparator.comparingInt(p -> p.pnum))
+                                .map(
+                                    UploadedPart::completedPart
+                                ).collect(Collectors.toList())
+                        ).build()
+                )
                 .build()
         ).thenApply(ignored -> null);
     }
@@ -155,5 +175,44 @@ final class MultipartUpload {
                     AsyncRequestBody.fromPublisher(content)
                 )
             );
+    }
+
+    /**
+     * Uploaded part.
+     * @since 1.12.0
+     */
+    private static class UploadedPart {
+        /**
+         * Part's number.
+         */
+        private final int pnum;
+
+        /**
+         * Entity tag for the uploaded object.
+         */
+        private final String tag;
+
+        /**
+         * Ctor.
+         *
+         * @param pnum Part's number.
+         * @param tag Entity tag for the uploaded object..
+         */
+        UploadedPart(final int pnum, final String tag) {
+            this.pnum = pnum;
+            this.tag = tag;
+        }
+
+        /**
+         * Builds {@code CompletedPart}.
+         *
+         * @return CompletedPart.
+         */
+        CompletedPart completedPart() {
+            return CompletedPart.builder()
+                .partNumber(this.pnum)
+                .eTag(this.tag)
+                .build();
+        }
     }
 }

--- a/src/test/java/com/artipie/asto/SplittingTest.java
+++ b/src/test/java/com/artipie/asto/SplittingTest.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto;
+
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Random;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Splitting}.
+ *
+ * @since 1.12.0
+ * @checkstyle MagicNumberCheck (500 lines)
+ */
+public class SplittingTest {
+
+    @Test
+    void shouldReturnOneByteBufferWhenOriginalLessSize() {
+        final byte[] data = new byte[12];
+        new Random().nextBytes(data);
+        final List<ByteBuffer> buffers = Flowable.fromPublisher(
+            new Splitting(ByteBuffer.wrap(data), 24).publisher()
+        ).toList().blockingGet();
+        MatcherAssert.assertThat(buffers.size(), Matchers.equalTo(1));
+        MatcherAssert.assertThat(
+            new Remaining(buffers.get(0)).bytes(), Matchers.equalTo(data)
+        );
+    }
+
+    @Test
+    void shouldReturnOneByteBufferWhenOriginalEqualsSize() {
+        final byte[] data = new byte[24];
+        new Random().nextBytes(data);
+        final List<ByteBuffer> buffers = Flowable.fromPublisher(
+            new Splitting(ByteBuffer.wrap(data), 24).publisher()
+        ).toList().blockingGet();
+        MatcherAssert.assertThat(buffers.size(), Matchers.equalTo(1));
+        MatcherAssert.assertThat(
+            new Remaining(buffers.get(0)).bytes(), Matchers.equalTo(data)
+        );
+    }
+
+    @Test
+    void shouldReturnSeveralByteBuffersWhenOriginalMoreSize() {
+        final byte[] data = new byte[2 * 24 + 8];
+        new Random().nextBytes(data);
+        final List<ByteBuffer> buffers = Flowable.fromPublisher(
+            new Splitting(ByteBuffer.wrap(data), 24).publisher()
+        ).toList().blockingGet();
+        MatcherAssert.assertThat(buffers.size(), Matchers.equalTo(3));
+        MatcherAssert.assertThat(
+            new Remaining(
+                new Concatenation(
+                    Flowable.fromIterable(buffers)
+                ).single().blockingGet()
+            ).bytes(), Matchers.equalTo(data)
+        );
+    }
+}

--- a/src/test/java/com/artipie/asto/s3/S3StorageTest.java
+++ b/src/test/java/com/artipie/asto/s3/S3StorageTest.java
@@ -30,7 +30,6 @@ import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsEmptyIterable;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -92,7 +91,6 @@ class S3StorageTest {
 
     @Test
     @Timeout(15)
-    @Disabled("https://github.com/artipie/asto/issues/421")
     void shouldUploadObjectWhenSaveLargeContent(final AmazonS3 client) throws Exception {
         final int size = 20 * 1024 * 1024;
         final byte[] data = new byte[size];


### PR DESCRIPTION
closes: #421

- created `Splitting` class to split `ByteBuffer` at parts
- created tests to check `Splitting` implementation
- added filling of `multipartUpload` field of `CompleteMultipartUploadRequest`