### PR TITLE
fix: StorageValuePipeline#processWithResult hanging

### DIFF
--- a/src/main/java/com/artipie/asto/streams/StorageValuePipeline.java
+++ b/src/main/java/com/artipie/asto/streams/StorageValuePipeline.java
@@ -133,7 +133,9 @@ public final class StorageValuePipeline<R> {
                                     () -> ref.set(
                                         action.apply(inpfrom, outto)
                                     )
-                                ).handle(inpfrom.map(stream -> new FutureHandler<>(stream, outto)
+                                ).handle(
+                                    inpfrom.map(
+                                        stream -> new FutureHandler<>(stream, outto)
                                     ).orElseGet(() -> new FutureHandler<>(outto))
                                 ),
                                 CompletableFuture.runAsync(


### PR DESCRIPTION
Close: #427
 - implemented asynchronous starting of read, action and write futures inside the `StorageValuePipeline#processWithResult` method.
 - added test to check `StorageValuePipeline` in the case when value is getting by key "from" has large size.