### PR TITLE
fix: verification base tests corrected and file storage fixed

### DIFF
--- a/asto-core/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/asto-core/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -88,7 +88,7 @@ public final class FileStorage implements Storage {
                     if (Key.ROOT.equals(prefix)) {
                         dirnamelen = path.toString().length() + 1;
                     } else {
-                        dirnamelen = path.toString().length() - prefix.string().length() + 1;
+                        dirnamelen = path.toString().length() - prefix.string().length();
                     }
                     try {
                         keys = Files.walk(path)

--- a/asto-core/src/main/java/com/artipie/asto/test/StorageWhiteboxVerification.java
+++ b/asto-core/src/main/java/com/artipie/asto/test/StorageWhiteboxVerification.java
@@ -30,8 +30,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 /**

--- a/asto-core/src/test/java/com/artipie/asto/FileStorageWhiteboxVerificationTest.java
+++ b/asto-core/src/test/java/com/artipie/asto/FileStorageWhiteboxVerificationTest.java
@@ -6,13 +6,9 @@ package com.artipie.asto;
 
 import com.artipie.asto.fs.FileStorage;
 import com.artipie.asto.test.StorageWhiteboxVerification;
-import java.io.File;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.stream.Stream;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * File storage verification test.
@@ -26,20 +22,8 @@ public final class FileStorageWhiteboxVerificationTest extends StorageWhiteboxVe
     /**
      * Temp test dir.
      */
+    @TempDir
     private Path temp;
-
-    @Before
-    public void setUp() throws Exception {
-        this.temp = Files.createTempDirectory("junit");
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        try (Stream<Path> walk = Files.walk(this.temp)) {
-            walk.map(Path::toFile)
-                .forEach(File::delete);
-        }
-    }
 
     @Override
     protected Storage newStorage() {

--- a/asto-etcd/src/test/java/com/artipie/asto/etcd/EtcdStorageVerificationTest.java
+++ b/asto-etcd/src/test/java/com/artipie/asto/etcd/EtcdStorageVerificationTest.java
@@ -9,8 +9,8 @@ import com.artipie.asto.test.StorageWhiteboxVerification;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.test.EtcdClusterExtension;
 import java.util.Optional;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
@@ -28,23 +28,6 @@ public final class EtcdStorageVerificationTest extends StorageWhiteboxVerificati
      */
     private static EtcdClusterExtension etcd;
 
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        EtcdStorageVerificationTest.etcd = new EtcdClusterExtension(
-            "test-etcd",
-            1,
-            false,
-            "--data-dir",
-            "/data.etcd0"
-        );
-        EtcdStorageVerificationTest.etcd.beforeAll(null);
-    }
-
-    @AfterClass
-    public static void afterClass() throws Exception {
-        EtcdStorageVerificationTest.etcd.afterAll(null);
-    }
-
     @Override
     protected Storage newStorage() throws Exception {
         return new EtcdStorage(
@@ -57,5 +40,22 @@ public final class EtcdStorageVerificationTest extends StorageWhiteboxVerificati
     @Override
     protected Optional<Storage> newBaseForRootSubStorage() {
         return Optional.empty();
+    }
+
+    @BeforeAll
+    static void beforeClass() throws Exception {
+        EtcdStorageVerificationTest.etcd = new EtcdClusterExtension(
+            "test-etcd",
+            1,
+            false,
+            "--data-dir",
+            "/data.etcd0"
+        );
+        EtcdStorageVerificationTest.etcd.beforeAll(null);
+    }
+
+    @AfterAll
+    static void afterClass() throws Exception {
+        EtcdStorageVerificationTest.etcd.afterAll(null);
     }
 }

--- a/asto-redis/src/test/java/com/artipie/asto/redis/RedisStorageWhiteboxVerificationTest.java
+++ b/asto-redis/src/test/java/com/artipie/asto/redis/RedisStorageWhiteboxVerificationTest.java
@@ -11,6 +11,8 @@ import com.artipie.asto.factory.Storages;
 import com.artipie.asto.test.StorageWhiteboxVerification;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.testcontainers.containers.GenericContainer;
 
 /**
@@ -20,6 +22,7 @@ import org.testcontainers.containers.GenericContainer;
  * @since 0.1
  */
 @SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.AvoidDuplicateLiterals"})
+@DisabledOnOs(OS.WINDOWS)
 public final class RedisStorageWhiteboxVerificationTest extends StorageWhiteboxVerification {
 
     /**

--- a/asto-redis/src/test/java/com/artipie/asto/redis/RedisStorageWhiteboxVerificationTest.java
+++ b/asto-redis/src/test/java/com/artipie/asto/redis/RedisStorageWhiteboxVerificationTest.java
@@ -9,8 +9,8 @@ import com.amihaiemil.eoyaml.YamlMapping;
 import com.artipie.asto.Storage;
 import com.artipie.asto.factory.Storages;
 import com.artipie.asto.test.StorageWhiteboxVerification;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.GenericContainer;
 
 /**
@@ -30,30 +30,31 @@ public final class RedisStorageWhiteboxVerificationTest extends StorageWhiteboxV
     /**
      * Redis test container.
      */
-    private GenericContainer<?> redis;
+    private static GenericContainer<?> redis;
 
     /**
      * Redis storage.
      */
-    private Storage storage;
-
-    @Before
-    public void setUp() {
-        this.redis = new GenericContainer<>("redis:3-alpine")
-            .withExposedPorts(RedisStorageWhiteboxVerificationTest.DEF_PORT);
-        this.redis.start();
-        this.storage = new Storages()
-            .newStorage("redis", config(this.redis.getFirstMappedPort()));
-    }
-
-    @After
-    public void tearDown() {
-        this.redis.stop();
-    }
+    private static Storage storage;
 
     @Override
     protected Storage newStorage() {
-        return this.storage;
+        return RedisStorageWhiteboxVerificationTest.storage;
+    }
+
+    @BeforeAll
+    static void setUp() {
+        RedisStorageWhiteboxVerificationTest.redis = new GenericContainer<>("redis:3-alpine")
+            .withExposedPorts(RedisStorageWhiteboxVerificationTest.DEF_PORT);
+        RedisStorageWhiteboxVerificationTest.redis.start();
+        RedisStorageWhiteboxVerificationTest.storage = new Storages().newStorage(
+            "redis", config(RedisStorageWhiteboxVerificationTest.redis.getFirstMappedPort())
+        );
+    }
+
+    @AfterAll
+    static void tearDown() {
+        RedisStorageWhiteboxVerificationTest.redis.stop();
     }
 
     private static YamlMapping config(final Integer port) {

--- a/asto-s3/src/test/java/com/artipie/asto/S3StorageWhiteboxVerificationTest.java
+++ b/asto-s3/src/test/java/com/artipie/asto/S3StorageWhiteboxVerificationTest.java
@@ -11,6 +11,8 @@ import java.net.URI;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -24,6 +26,7 @@ import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
  * @since 0.1
  */
 @SuppressWarnings("PMD.TestClassWithoutTestCases")
+@DisabledOnOs(OS.WINDOWS)
 public final class S3StorageWhiteboxVerificationTest extends StorageWhiteboxVerification {
 
     /**

--- a/asto-s3/src/test/java/com/artipie/asto/S3StorageWhiteboxVerificationTest.java
+++ b/asto-s3/src/test/java/com/artipie/asto/S3StorageWhiteboxVerificationTest.java
@@ -9,8 +9,8 @@ import com.artipie.asto.s3.S3Storage;
 import com.artipie.asto.test.StorageWhiteboxVerification;
 import java.net.URI;
 import java.util.UUID;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -29,19 +29,8 @@ public final class S3StorageWhiteboxVerificationTest extends StorageWhiteboxVeri
     /**
      * S3 mock server extension.
      */
-    private final S3MockExtension mock = S3MockExtension.builder()
-        .withSecureConnection(false)
-        .build();
-
-    @Before
-    public void setUp() throws Exception {
-        this.mock.beforeAll(null);
-    }
-
-    @After
-    public void tearDown() {
-        this.mock.afterAll(null);
-    }
+    private static final S3MockExtension MOCK = S3MockExtension.builder()
+        .withSecureConnection(false).build();
 
     @Override
     protected Storage newStorage() {
@@ -53,11 +42,22 @@ public final class S3StorageWhiteboxVerificationTest extends StorageWhiteboxVeri
                 )
             )
             .endpointOverride(
-                URI.create(String.format("http://localhost:%d", this.mock.getHttpPort()))
+                URI.create(String.format("http://localhost:%d", MOCK.getHttpPort()))
             )
             .build();
         final String bucket = UUID.randomUUID().toString();
         client.createBucket(CreateBucketRequest.builder().bucket(bucket).build()).join();
         return new S3Storage(client, bucket);
     }
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        S3StorageWhiteboxVerificationTest.MOCK.beforeAll(null);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        S3StorageWhiteboxVerificationTest.MOCK.afterAll(null);
+    }
+
 }

--- a/asto-vertx-file/src/main/java/com/artipie/asto/fs/VertxFileStorage.java
+++ b/asto-vertx-file/src/main/java/com/artipie/asto/fs/VertxFileStorage.java
@@ -88,7 +88,7 @@ public final class VertxFileStorage implements Storage {
                     if (Key.ROOT.equals(prefix)) {
                         dirnamelen = path.toString().length() + 1;
                     } else {
-                        dirnamelen = path.toString().length() - prefix.string().length() + 1;
+                        dirnamelen = path.toString().length() - prefix.string().length();
                     }
                     try {
                         keys = Files.walk(path)

--- a/asto-vertx-file/src/test/java/com/artipie/asto/VertxFileStorageVerificationTest.java
+++ b/asto-vertx-file/src/test/java/com/artipie/asto/VertxFileStorageVerificationTest.java
@@ -7,13 +7,10 @@ package com.artipie.asto;
 import com.artipie.asto.fs.VertxFileStorage;
 import com.artipie.asto.test.StorageWhiteboxVerification;
 import io.vertx.reactivex.core.Vertx;
-import java.io.File;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.stream.Stream;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Vertx file storage verification test.
@@ -25,50 +22,45 @@ import org.junit.Before;
 public final class VertxFileStorageVerificationTest extends StorageWhiteboxVerification {
 
     /**
-     * Temp dir.
-     */
-    private Path temp;
-
-    /**
      * Vert.x file System.
      */
-    private Vertx vertx;
+    private static final Vertx VERTX = Vertx.vertx();
 
-    @Before
-    public void setUp() throws Exception {
-        this.vertx = Vertx.vertx();
-        this.temp = Files.createTempDirectory("vtx_junit");
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        this.vertx.close();
-        try (Stream<Path> walk = Files.walk(this.temp)) {
-            walk.map(Path::toFile)
-                .forEach(File::delete);
-        }
-    }
+    /**
+     * Temp dir.
+     */
+    @TempDir
+    private Path temp;
 
     @Override
     protected Storage newStorage() throws Exception {
         return new VertxFileStorage(
             this.temp.resolve("base"),
-            this.vertx
+            VertxFileStorageVerificationTest.VERTX
         );
     }
 
     @Override
     protected Optional<Storage> newBaseForRootSubStorage() {
         return Optional.of(
-            new VertxFileStorage(this.temp.resolve("root-sub-storage"), this.vertx)
+            new VertxFileStorage(
+                this.temp.resolve("root-sub-storage"), VertxFileStorageVerificationTest.VERTX
+            )
         );
     }
 
     @Override
     protected Optional<Storage> newBaseForSubStorage() {
         return Optional.of(
-            new VertxFileStorage(this.temp.resolve("sub-storage"), this.vertx)
+            new VertxFileStorage(
+                this.temp.resolve("sub-storage"), VertxFileStorageVerificationTest.VERTX
+            )
         );
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        VertxFileStorageVerificationTest.VERTX.close();
     }
 
 }


### PR DESCRIPTION
Whitebox Verification base test should use junit jupiter `Test` annotation to actually run the tests for various storages and I've fixed error in `FileStorage.list()` method (we could not have missed it if Verification test was actually working).