### PR TITLE
feat: storage identifier

### DIFF
--- a/asto-core/src/main/java/com/artipie/asto/LoggingStorage.java
+++ b/asto-core/src/main/java/com/artipie/asto/LoggingStorage.java
@@ -162,6 +162,11 @@ public final class LoggingStorage implements Storage {
         );
     }
 
+    @Override
+    public String identifier() {
+        return String.format("Logging: %s", this.storage.identifier());
+    }
+
     /**
      * Log message.
      *

--- a/asto-core/src/main/java/com/artipie/asto/Storage.java
+++ b/asto-core/src/main/java/com/artipie/asto/Storage.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
  *
  * @since 0.1
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public interface Storage {
 
     /**
@@ -132,6 +133,16 @@ public interface Storage {
     );
 
     /**
+     * Get storage identifier. Returned string should allow identifying storage and provide some
+     * unique storage information allowing to concrete determine storage instance. For example, for
+     * file system storage, it could provide the type and path, for s3 - base url and username.
+     * @return String storage identifier
+     */
+    default String identifier() {
+        return getClass().getSimpleName();
+    }
+
+    /**
      * Forwarding decorator for {@link Storage}.
      *
      * @since 0.18
@@ -203,6 +214,11 @@ public interface Storage {
         @Override
         public CompletableFuture<? extends Meta> metadata(final Key key) {
             return this.delegate.metadata(key);
+        }
+
+        @Override
+        public String identifier() {
+            return this.delegate.identifier();
         }
     }
 }

--- a/asto-core/src/main/java/com/artipie/asto/SubStorage.java
+++ b/asto-core/src/main/java/com/artipie/asto/SubStorage.java
@@ -108,6 +108,13 @@ public final class SubStorage implements Storage {
         return new UnderLockOperation<>(new StorageLock(this, key), operation).perform(this);
     }
 
+    @Override
+    public String identifier() {
+        return String.format(
+            "SubStorage: prefix=%s, origin=%s", this.prefix, this.origin.identifier()
+        );
+    }
+
     /**
      * Key with prefix.
      * @since 0.21

--- a/asto-core/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/asto-core/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -231,6 +231,11 @@ public final class FileStorage implements Storage {
         return new UnderLockOperation<>(new StorageLock(this, key), operation).perform(this);
     }
 
+    @Override
+    public String identifier() {
+        return String.format("FS: %s", this.dir.toString());
+    }
+
     /**
      * Removes empty key parts (directories).
      * @param target Directory path

--- a/asto-core/src/test/java/com/artipie/asto/FileStorageTest.java
+++ b/asto-core/src/test/java/com/artipie/asto/FileStorageTest.java
@@ -305,6 +305,14 @@ final class FileStorageTest {
         );
     }
 
+    @Test
+    void returnsIdentifier() {
+        MatcherAssert.assertThat(
+            this.storage.identifier(),
+            Matchers.stringContainsInOrder("FS", this.tmp.toString())
+        );
+    }
+
     /**
      * Create a directory.
      * @param parent Directory parent path

--- a/asto-etcd/src/main/java/com/artipie/asto/etcd/EtcdStorage.java
+++ b/asto-etcd/src/main/java/com/artipie/asto/etcd/EtcdStorage.java
@@ -61,11 +61,19 @@ public final class EtcdStorage implements Storage {
     private final Client client;
 
     /**
-     * Ctor.
-     * @param client Etcd client
+     * Endpoints of this storage etcd client.
      */
-    public EtcdStorage(final Client client) {
+    private final String endpoints;
+
+    /**
+     * Ctor.
+     *
+     * @param client Etcd client
+     * @param endpoints Endpoints of this storage etcd client
+     */
+    public EtcdStorage(final Client client, final String endpoints) {
         this.client = client;
+        this.endpoints = endpoints;
     }
 
     @Override
@@ -176,6 +184,11 @@ public final class EtcdStorage implements Storage {
     public <T> CompletionStage<T> exclusively(final Key key,
         final Function<Storage, CompletionStage<T>> operation) {
         return new UnderLockOperation<>(new StorageLock(this, key), operation).perform(this);
+    }
+
+    @Override
+    public String identifier() {
+        return String.format("Etcd: %s", this.endpoints);
     }
 
     /**

--- a/asto-etcd/src/main/java/com/artipie/asto/etcd/EtcdStorageFactory.java
+++ b/asto-etcd/src/main/java/com/artipie/asto/etcd/EtcdStorageFactory.java
@@ -11,6 +11,7 @@ import com.artipie.asto.factory.StorageFactory;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.ClientBuilder;
 import java.time.Duration;
+import java.util.Arrays;
 
 /**
  * Etcd storage factory.
@@ -22,14 +23,12 @@ public final class EtcdStorageFactory implements StorageFactory {
     public Storage newStorage(final StorageConfig cfg) {
         final StorageConfig connection = new StorageConfig.StrictStorageConfig(cfg)
             .config("connection");
-        final ClientBuilder builder = Client.builder()
-            .endpoints(
-                connection.sequence("endpoints").toArray(new String[0])
-            );
+        final String[] endpoints = connection.sequence("endpoints").toArray(new String[0]);
+        final ClientBuilder builder = Client.builder().endpoints(endpoints);
         final String sto = connection.string("timeout");
         if (sto != null) {
             builder.connectTimeout(Duration.ofMillis(Integer.parseInt(sto)));
         }
-        return new EtcdStorage(builder.build());
+        return new EtcdStorage(builder.build(), Arrays.toString(endpoints));
     }
 }

--- a/asto-etcd/src/test/java/com/artipie/asto/etcd/EtcdStorageVerificationTest.java
+++ b/asto-etcd/src/test/java/com/artipie/asto/etcd/EtcdStorageVerificationTest.java
@@ -8,7 +8,10 @@ import com.artipie.asto.Storage;
 import com.artipie.asto.test.StorageWhiteboxVerification;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.test.EtcdClusterExtension;
+import java.net.URI;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -29,11 +32,11 @@ public final class EtcdStorageVerificationTest extends StorageWhiteboxVerificati
     private static EtcdClusterExtension etcd;
 
     @Override
-    protected Storage newStorage() throws Exception {
+    protected Storage newStorage() {
+        final List<URI> endpoints = EtcdStorageVerificationTest.etcd.getClientEndpoints();
         return new EtcdStorage(
-            Client.builder()
-                .endpoints(EtcdStorageVerificationTest.etcd.getClientEndpoints())
-                .build()
+            Client.builder().endpoints(endpoints).build(),
+            endpoints.stream().map(URI::toString).collect(Collectors.joining())
         );
     }
 

--- a/asto-redis/src/main/java/com/artipie/asto/redis/RedisStorage.java
+++ b/asto-redis/src/main/java/com/artipie/asto/redis/RedisStorage.java
@@ -42,12 +42,19 @@ public final class RedisStorage implements Storage {
     private final RMapAsync<String, byte[]> data;
 
     /**
+     * Redisson instance id, example: b0d9b09f-7c45-4a22-a8b7-c4979b65476a.
+     */
+    private final String id;
+
+    /**
      * Ctor.
      *
      * @param data Async interface for Redis.
+     * @param id Redisson instance id
      */
-    public RedisStorage(final RMapAsync<String, byte[]> data) {
+    public RedisStorage(final RMapAsync<String, byte[]> data, final String id) {
         this.data = data;
+        this.id = id;
     }
 
     @Override
@@ -177,6 +184,11 @@ public final class RedisStorage implements Storage {
                     throw new ValueNotFoundException(key);
                 }
             ).toCompletableFuture();
+    }
+
+    @Override
+    public String identifier() {
+        return String.format("Radis: id=%s", this.id);
     }
 
     /**

--- a/asto-redis/src/main/java/com/artipie/asto/redis/RedisStorageFactory.java
+++ b/asto-redis/src/main/java/com/artipie/asto/redis/RedisStorageFactory.java
@@ -39,7 +39,7 @@ public final class RedisStorageFactory implements StorageFactory {
                         .string("config")
                 )
             );
-            return new RedisStorage(redisson.getMap(name));
+            return new RedisStorage(redisson.getMap(name), redisson.getId());
         } catch (final IOException err) {
             throw new ArtipieIOException(err);
         }

--- a/asto-redis/src/test/java/com/artipie/asto/redis/RedisStorageTest.java
+++ b/asto-redis/src/test/java/com/artipie/asto/redis/RedisStorageTest.java
@@ -223,6 +223,14 @@ public final class RedisStorageTest {
         );
     }
 
+    @Test
+    void returnsIdentifier() {
+        MatcherAssert.assertThat(
+            this.storage.identifier(),
+            Matchers.stringContainsInOrder("Radis", "id=")
+        );
+    }
+
     private static YamlMapping config(final Integer port) {
         return Yaml.createYamlMappingBuilder()
             .add("type", "redis")

--- a/asto-s3/src/main/java/com/artipie/asto/s3/S3Storage.java
+++ b/asto-s3/src/main/java/com/artipie/asto/s3/S3Storage.java
@@ -48,6 +48,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
  *  but it makes testing the method difficult.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class S3Storage implements Storage {
 
     /**
@@ -71,13 +72,19 @@ public final class S3Storage implements Storage {
     private final boolean multipart;
 
     /**
+     * Endpoint of the storage S3 client.
+     */
+    private final String endpoint;
+
+    /**
      * Ctor.
      *
      * @param client S3 client.
      * @param bucket Bucket name.
+     * @param endpoint S3 client endpoint
      */
-    public S3Storage(final S3AsyncClient client, final String bucket) {
-        this(client, bucket, true);
+    public S3Storage(final S3AsyncClient client, final String bucket, final String endpoint) {
+        this(client, bucket, true, endpoint);
     }
 
     /**
@@ -88,11 +95,15 @@ public final class S3Storage implements Storage {
      * @param multipart Multipart allowed flag.
      *  <code>true</code> - if multipart feature is allowed for larger blobs,
      *  <code>false</code> otherwise.
+     * @param endpoint S3 client endpoint
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
-    public S3Storage(final S3AsyncClient client, final String bucket, final boolean multipart) {
+    public S3Storage(final S3AsyncClient client, final String bucket, final boolean multipart,
+        final String endpoint) {
         this.client = client;
         this.bucket = bucket;
         this.multipart = multipart;
+        this.endpoint = endpoint;
     }
 
     @Override
@@ -250,6 +261,11 @@ public final class S3Storage implements Storage {
         final Function<Storage, CompletionStage<T>> operation
     ) {
         return new UnderLockOperation<>(new StorageLock(this, key), operation).perform(this);
+    }
+
+    @Override
+    public String identifier() {
+        return String.format("S3: %s %s", this.endpoint, this.bucket);
     }
 
     /**

--- a/asto-s3/src/test/java/com/artipie/asto/S3StorageWhiteboxVerificationTest.java
+++ b/asto-s3/src/test/java/com/artipie/asto/S3StorageWhiteboxVerificationTest.java
@@ -37,6 +37,7 @@ public final class S3StorageWhiteboxVerificationTest extends StorageWhiteboxVeri
 
     @Override
     protected Storage newStorage() {
+        final String endpoint = String.format("http://localhost:%d", MOCK.getHttpPort());
         final S3AsyncClient client = S3AsyncClient.builder()
             .region(Region.of("us-east-1"))
             .credentialsProvider(
@@ -44,13 +45,11 @@ public final class S3StorageWhiteboxVerificationTest extends StorageWhiteboxVeri
                     AwsBasicCredentials.create("foo", "bar")
                 )
             )
-            .endpointOverride(
-                URI.create(String.format("http://localhost:%d", MOCK.getHttpPort()))
-            )
+            .endpointOverride(URI.create(endpoint))
             .build();
         final String bucket = UUID.randomUUID().toString();
         client.createBucket(CreateBucketRequest.builder().bucket(bucket).build()).join();
-        return new S3Storage(client, bucket);
+        return new S3Storage(client, bucket, endpoint);
     }
 
     @BeforeAll

--- a/asto-s3/src/test/java/com/artipie/asto/s3/S3StorageTest.java
+++ b/asto-s3/src/test/java/com/artipie/asto/s3/S3StorageTest.java
@@ -242,6 +242,16 @@ class S3StorageTest {
         );
     }
 
+    @Test
+    void returnsIdentifier() {
+        MatcherAssert.assertThat(
+            this.storage().identifier(),
+            Matchers.stringContainsInOrder(
+                "S3", "http://localhost", String.valueOf(MOCK.getHttpPort()), this.bucket
+            )
+        );
+    }
+
     private byte[] download(final AmazonS3 client, final String key) throws IOException {
         try (S3Object s3Object = client.getObject(this.bucket, key)) {
             return ByteStreams.toByteArray(s3Object.getObjectContent());
@@ -249,15 +259,14 @@ class S3StorageTest {
     }
 
     private S3Storage storage() {
+        final String endpoint = String.format("http://localhost:%d", MOCK.getHttpPort());
         final S3AsyncClient client = S3AsyncClient.builder()
             .region(Region.of("us-east-1"))
             .credentialsProvider(
                 StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar"))
             )
-            .endpointOverride(
-                URI.create(String.format("http://localhost:%d", MOCK.getHttpPort()))
-            )
+            .endpointOverride(URI.create(endpoint))
             .build();
-        return new S3Storage(client, this.bucket);
+        return new S3Storage(client, this.bucket, endpoint);
     }
 }

--- a/asto-vertx-file/src/main/java/com/artipie/asto/fs/VertxFileStorage.java
+++ b/asto-vertx-file/src/main/java/com/artipie/asto/fs/VertxFileStorage.java
@@ -223,6 +223,11 @@ public final class VertxFileStorage implements Storage {
         return CompletableFuture.completedFuture(Meta.EMPTY);
     }
 
+    @Override
+    public String identifier() {
+        return String.format("Vertx FS: %s", this.dir.toString());
+    }
+
     /**
      * Resolves key to file system path.
      *


### PR DESCRIPTION
Closes #480

Added default method to get some storage identifier into `Storage` interface and overrode it where required.