### PR TITLE
S3 credentials should be optional

### DIFF
--- a/asto-core/src/main/java/com/artipie/asto/factory/Config.java
+++ b/asto-core/src/main/java/com/artipie/asto/factory/Config.java
@@ -43,6 +43,13 @@ public interface Config {
     Config config(String key);
 
     /**
+     * Checks that there is a config data.
+     *
+     * @return True if no config data.
+     */
+    boolean isEmpty();
+
+    /**
      * Strict storage config throws {@code NullPointerException} when value is not exist.
      *
      * @since 1.13.0
@@ -85,6 +92,11 @@ public interface Config {
                 this.original.config(key),
                 String.format("No config found for key %s", key)
             );
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return this.original == null || this.original.isEmpty();
         }
     }
 
@@ -147,6 +159,11 @@ public interface Config {
         @Override
         public Config config(final String key) {
             return new YamlStorageConfig(this.original.yamlMapping(key));
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return this.original == null || this.original.isEmpty();
         }
 
         @Override

--- a/asto-s3/src/test/java/com/artipie/asto/S3StorageFactoryTest.java
+++ b/asto-s3/src/test/java/com/artipie/asto/S3StorageFactoryTest.java
@@ -26,7 +26,7 @@ public final class S3StorageFactoryTest {
      * @checkstyle MethodNameCheck (3 lines)
      */
     @Test
-    void shouldCreateS3Storage() {
+    void shouldCreateS3StorageConfigHasCredentials() {
         MatcherAssert.assertThat(
             new StoragesLoader()
                 .newObject(
@@ -44,6 +44,29 @@ public final class S3StorageFactoryTest {
                                     .add("secretAccessKey", "bar")
                                     .build()
                             )
+                            .build()
+                    )
+                ),
+            new IsInstanceOf(S3Storage.class)
+        );
+    }
+
+    /**
+     * Test for S3 storage factory.
+     *
+     * @checkstyle MethodNameCheck (3 lines)
+     */
+    @Test
+    void shouldCreateS3StorageConfigDoesNotHaveCredentials() {
+        MatcherAssert.assertThat(
+            new StoragesLoader()
+                .newObject(
+                    "s3",
+                    new Config.YamlStorageConfig(
+                        Yaml.createYamlMappingBuilder()
+                            .add("region", "us-east-1")
+                            .add("bucket", "aaa")
+                            .add("endpoint", "http://localhost")
                             .build()
                     )
                 ),

--- a/asto-s3/src/test/java/com/artipie/asto/s3/S3HeadMetaTest.java
+++ b/asto-s3/src/test/java/com/artipie/asto/s3/S3HeadMetaTest.java
@@ -25,7 +25,7 @@ final class S3HeadMetaTest {
                     .contentLength(len)
                     .eTag("empty")
                     .build()
-            ).read(Meta.OP_SIZE).get(),
+            ).read(Meta.OP_SIZE).orElseThrow(IllegalStateException::new),
             new IsEqual<>(len)
         );
     }
@@ -39,7 +39,7 @@ final class S3HeadMetaTest {
                     .contentLength(0L)
                     .eTag(hash)
                     .build()
-            ).read(Meta.OP_MD5).get(),
+            ).read(Meta.OP_MD5).orElseThrow(IllegalStateException::new),
             new IsEqual<>(hash)
         );
     }


### PR DESCRIPTION
Close https://github.com/artipie/artipie/issues/1281

- credentials are made optional for S3 storage factory; added test;
- added using S3 storage factory to get a storage instance in tests.