### PR TITLE
feat: added quartz and scheduled jobs

### DIFF
--- a/asto-core/pom.xml
+++ b/asto-core/pom.xml
@@ -61,6 +61,11 @@ SOFTWARE.
       <version>0.20.10</version>
     </dependency>
     <dependency>
+      <groupId>org.quartz-scheduler</groupId>
+      <artifactId>quartz</artifactId>
+      <version>2.3.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.cqfn</groupId>
       <artifactId>rio</artifactId>
       <version>0.3</version>
@@ -85,6 +90,18 @@ SOFTWARE.
       <groupId>org.reactivestreams</groupId>
       <artifactId>reactive-streams-tck</artifactId>
       <version>1.0.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.2.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.8.0-alpha2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/asto-core/src/main/java/com/artipie/asto/events/EventQueue.java
+++ b/asto-core/src/main/java/com/artipie/asto/events/EventQueue.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2023 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.events;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Events queue with {@link ConcurrentLinkedQueue} under the hood.
+ * Instance of this class can be passed where necessary (to the adapters for example)
+ * to add data for processing into the queue.
+ * @param <T> Queue item parameter type.
+ * @since 1.17
+ */
+public final class EventQueue<T> {
+
+    /**
+     * Queue.
+     */
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
+    private final Queue<T> queue;
+
+    /**
+     * Ctor.
+     */
+    public EventQueue() {
+        this.queue = new ConcurrentLinkedQueue<>();
+    }
+
+    /**
+     * Add item to queue.
+     * @param item Element to add
+     */
+    public void put(final T item) {
+        this.queue.add(item);
+    }
+
+    /**
+     * Queue, not public intentionally, the queue should be accessible only from this package.
+     * @return The queue.
+     */
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
+    Queue<T> queue() {
+        return this.queue;
+    }
+}

--- a/asto-core/src/main/java/com/artipie/asto/events/EventsProcessor.java
+++ b/asto-core/src/main/java/com/artipie/asto/events/EventsProcessor.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2023 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.events;
+
+import com.artipie.ArtipieException;
+import com.jcabi.log.Logger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Consumer;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
+import org.quartz.impl.StdSchedulerFactory;
+
+/**
+ * Job to process events from queue.
+ * Class type is used as quarts job type and is instantiated inside {@link org.quartz}, so
+ * this class must have empty ctor. Events queue and action to consume the event are
+ * obtained from job context.
+ * @param <T> Elements type to process
+ * @since 1.17
+ */
+public final class EventsProcessor<T> implements Job {
+
+    /**
+     * Pack size.
+     */
+    private static final int PACK_SIZE = 10;
+
+    /**
+     * Elements.
+     */
+    private EventQueue<T> elements;
+
+    /**
+     * Action to perform on element.
+     */
+    private Consumer<Collection<T>> action;
+
+    @Override
+    public void execute(final JobExecutionContext context) {
+        this.setAction(context);
+        this.setElements(context);
+        if (this.action == null || this.elements == null) {
+            final JobKey key = context.getJobDetail().getKey();
+            try {
+                Logger.error(
+                    this,
+                    String.format(
+                        "Events queue or action is null, processing failed. Stopping job %s...", key
+                    )
+                );
+                new StdSchedulerFactory().getScheduler().deleteJob(key);
+                Logger.error(this, String.format("Job %s stopped.", key));
+            } catch (final SchedulerException error) {
+                Logger.error(this, String.format("Error while stopping job %s", key));
+                throw new ArtipieException(error);
+            }
+        } else {
+            while (!this.elements.queue().isEmpty()) {
+                final Collection<T> list = new ArrayList<>(EventsProcessor.PACK_SIZE);
+                for (int ind = 0; ind < EventsProcessor.PACK_SIZE; ind = ind + 1) {
+                    final T item = this.elements.queue().poll();
+                    if (item == null) {
+                        break;
+                    } else {
+                        list.add(item);
+                    }
+                }
+                this.action.accept(list);
+            }
+        }
+    }
+
+    /**
+     * Set elements queue from job context.
+     * @param context Job context
+     */
+    @SuppressWarnings("unchecked")
+    public void setElements(final JobExecutionContext context) {
+        if (this.elements == null) {
+            final Object obj = context.getJobDetail().getJobDataMap().get("elements");
+            if (obj instanceof EventQueue) {
+                this.elements = (EventQueue<T>) obj;
+            }
+        }
+    }
+
+    /**
+     * Set elements consumer from job context.
+     * @param context Job context
+     */
+    @SuppressWarnings("unchecked")
+    public void setAction(final JobExecutionContext context) {
+        if (this.action == null) {
+            final Object obj = context.getJobDetail().getJobDataMap().get("action");
+            if (obj instanceof Consumer) {
+                this.action = (Consumer<Collection<T>>) obj;
+            }
+        }
+    }
+}

--- a/asto-core/src/main/java/com/artipie/asto/events/QuartsService.java
+++ b/asto-core/src/main/java/com/artipie/asto/events/QuartsService.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2023 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.events;
+
+import com.artipie.ArtipieException;
+import com.jcabi.log.Logger;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.TriggerBuilder;
+import org.quartz.impl.StdSchedulerFactory;
+
+/**
+ * Start quarts service.
+ * @since 1.17
+ */
+public final class QuartsService {
+
+    /**
+     * Quartz scheduler.
+     */
+    private final Scheduler scheduler;
+
+    /**
+     * Ctor.
+     */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+    public QuartsService() {
+        try {
+            this.scheduler = new StdSchedulerFactory().getScheduler();
+            Runtime.getRuntime().addShutdownHook(
+                new Thread() {
+                    @Override
+                    public void run() {
+                        try {
+                            QuartsService.this.scheduler.shutdown();
+                        } catch (final SchedulerException error) {
+                            Logger.error(this, error.getMessage());
+                        }
+                    }
+                }
+            );
+        } catch (final SchedulerException error) {
+            throw new ArtipieException(error);
+        }
+    }
+
+    /**
+     * Adds event processor to the quarts job. The job is repeating forever every
+     * given seconds.
+     * @param queue Queue to get data from
+     * @param consumer How to consume the data collection
+     * @param seconds Seconds interval for scheduling
+     * @param <T> Data item object type
+     * @throws SchedulerException On error
+     */
+    public <T> void addPeriodicEventsProcessor(
+        final EventQueue<T> queue, final Consumer<Collection<T>> consumer, final int seconds
+    ) throws SchedulerException {
+        final JobDataMap data = new JobDataMap();
+        data.put("elements", queue);
+        data.put("action", consumer);
+        final String id = String.join(
+            "-", EventsProcessor.class.getSimpleName(), UUID.randomUUID().toString()
+        );
+        this.scheduler.scheduleJob(
+            JobBuilder.newJob(EventsProcessor.class)
+                .withIdentity(String.join("-", "job", id))
+                .setJobData(data).build(),
+            TriggerBuilder.newTrigger()
+                .withIdentity(String.join("-", "trigger", id))
+                .startNow()
+                .withSchedule(SimpleScheduleBuilder.repeatSecondlyForever(seconds))
+                .build()
+        );
+    }
+
+    /**
+     * Start quartz.
+     */
+    public void start() {
+        try {
+            this.scheduler.start();
+        } catch (final SchedulerException error) {
+            throw new ArtipieException(error);
+        }
+    }
+
+}

--- a/asto-core/src/main/java/com/artipie/asto/events/package-info.java
+++ b/asto-core/src/main/java/com/artipie/asto/events/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2023 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+
+/**
+ * Events processing.
+ *
+ * @since 1.17
+ */
+package com.artipie.asto.events;

--- a/asto-core/src/test/java/com/artipie/asto/events/QuartsServiceTest.java
+++ b/asto-core/src/test/java/com/artipie/asto/events/QuartsServiceTest.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2023 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+package com.artipie.asto.events;
+
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.quartz.SchedulerException;
+import org.quartz.impl.StdSchedulerFactory;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+/**
+ * Test for {@link QuartsService}.
+ * @since 1.17
+ * @checkstyle IllegalTokenCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
+ */
+class QuartsServiceTest {
+
+    /**
+     * Quartz service to test.
+     */
+    private QuartsService service;
+
+    @BeforeEach
+    void init() {
+        this.service = new QuartsService();
+    }
+
+    @Test
+    void runsQuartsJobs() throws SchedulerException, InterruptedException {
+        final EventQueue<Character> queue = new EventQueue<>();
+        final TestConsumer consumer = new TestConsumer();
+        this.service.addPeriodicEventsProcessor(queue, consumer, 1);
+        this.service.start();
+        for (char sym = 'a'; sym <= 'z'; sym++) {
+            queue.put(sym);
+            if ((int) sym % 5 == 0) {
+                Thread.sleep(1500);
+            }
+        }
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> consumer.cnt.get() == 26);
+    }
+
+    @Test
+    void stopsJobIfDataAreNotPresent() throws SchedulerException {
+        this.service.addPeriodicEventsProcessor(null, new TestConsumer(), 1);
+        this.service.start();
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(
+            () -> new StdSchedulerFactory().getScheduler().getCurrentlyExecutingJobs().isEmpty()
+        );
+    }
+
+    /**
+     * Test consumer.
+     * @since 1.17
+     */
+    static final class TestConsumer implements Consumer<Collection<Character>> {
+
+        /**
+         * Count for accept method call.
+         */
+        private final AtomicInteger cnt = new AtomicInteger();
+
+        @Override
+        public void accept(final Collection<Character> strings) {
+            strings.forEach(ignored -> this.cnt.incrementAndGet());
+        }
+    }
+
+}

--- a/asto-core/src/test/java/com/artipie/asto/events/package-info.java
+++ b/asto-core/src/test/java/com/artipie/asto/events/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2023 artipie.com
+ * https://github.com/artipie/asto/LICENSE.txt
+ */
+
+/**
+ * Events processing tests.
+ *
+ * @since 1.17
+ */
+package com.artipie.asto.events;


### PR DESCRIPTION
part of #502 
Added skeleton for periodic processing of some data from queue. The idea is to use it for gathering and processing some events data from adapters. Implementation is based on [quartz scheduler](http://www.quartz-scheduler.org/). Quartz is strong open source scheduler, support clustering and a lot of other features. 
- `QuartsService` class is the main class to start scheduling and add some jobs
- `EventsProcessor` is quartz job to process pack of elements from queue using provided consumer
- `EventQueue` is the queue to gather data for processing

Data can be any object, for example, info about added package (name, version, owner atc). Consumer knows what to do with the pack of data, for example, it can write data to db.